### PR TITLE
Fix compatibility with boost 1.56+

### DIFF
--- a/include/valijson/schema.hpp
+++ b/include/valijson/schema.hpp
@@ -174,7 +174,7 @@ public:
      */
     bool hasId() const
     {
-        return id;
+        return id != boost::none;
     }
 
     /**
@@ -185,7 +185,7 @@ public:
      */
     bool hasTitle() const
     {
-        return title;
+        return title != boost::none;
     }
 
     std::string resolveUri(const std::string &relative) const


### PR DESCRIPTION
In boost 1.56 the optional library is no longer happy with the implicit
conversion from boost::optionalstd::string to bool, so we get the following
errors:

```
valijson/include/valijson/schema.hpp:177:16: error: no viable conversion from 'const boost::optional<std::string>' to 'bool'
        return id;
               ^~

valijson/include/valijson/schema.hpp:188:16: error: no viable conversion from 'const boost::optional<std::string>' to 'bool'
                return title;
                       ^~~~~
2 errors generated.
```

Here we explicitly test against boost::none instead.
