### PR TITLE
fixups needed for boost 1.57

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,13 @@ add_library(jsoncpp
 add_subdirectory(thirdparty/gtest-1.7.0)
 
 # Include path
-include_directories(include thirdparty/gtest-1.7.0/include thirdparty/jsoncpp-0.5.0/include thirdparty/rapidjson-0.1/include)
+include_directories(
+  include
+  thirdparty/gtest-1.7.0/include
+  thirdparty/jsoncpp-0.5.0/include
+  thirdparty/rapidjson-0.1/include
+  ${Boost_INCLUDE_DIRS}
+)
 
 # External schema validation example
 add_executable(external_schema

--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -927,11 +927,12 @@ public:
 
         const typename AdapterType::Array targetArray = target.getArray();
         const typename AdapterType::Array::const_iterator end = targetArray.end();
-        const typename AdapterType::Array::const_iterator secondLast = end - 1;
+        const typename AdapterType::Array::const_iterator secondLast = --targetArray.end();
         unsigned int outerIndex = 0;
         for (typename AdapterType::Array::const_iterator outerItr = targetArray.begin(); outerItr != secondLast; ++outerItr) {
             unsigned int innerIndex = 0;
-            for (typename AdapterType::Array::const_iterator innerItr = outerItr + 1; innerItr != end; ++innerItr) {
+            typename AdapterType::Array::const_iterator innerItr(outerItr);
+            for (++innerItr; innerItr != end; ++innerItr) {
                 if (outerItr->equalTo(*innerItr, true)) {
                     if (results) {
                         results->pushError(context, "Elements at indexes #" +


### PR DESCRIPTION
boost 1.57 has changed the implementation of iterators, now requires this patch to build.  Have tested against 1.55 and 1.57 to ensure it didn't break older versions differently.