### PR TITLE
#7 Generalize rapidjson adapter for GenericValue

### DIFF
--- a/include/valijson/utils/rapidjson_utils.hpp
+++ b/include/valijson/utils/rapidjson_utils.hpp
@@ -8,7 +8,8 @@
 namespace valijson {
 namespace utils {
 
-inline bool loadDocument(const std::string &path, rapidjson::Document &document)
+template<class DocumentType>
+inline bool loadDocument(const std::string &path, DocumentType &document)
 {
     // Load schema JSON from file
     std::string file;


### PR DESCRIPTION
We've found the rapidjson MemoryPoolAllocator is buggy on SPARC, and for
the moment we're avoiding it as not being a large performance benefit.
The adapter assumes MemoryPoolAllocator, so we can't use valijson
without it. Templatize the rapidjson adapter so it can be used more
generically.