### PR TITLE
Remove boost from valijson base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,6 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-4.9', 'valgrind', 'python-pip', 'python-yaml']
-      env: COMPILER=g++-4.9
-
-    - os: linux
-      compiler: gcc
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-5', 'valgrind']
       env: COMPILER=g++-5
 

--- a/Authors
+++ b/Authors
@@ -18,3 +18,6 @@ Michael Smith, michael.smith@puppetlabs.com
 
 Richard Clamp, richardc@unixbeard.net
 	Boost-related fixes
+
+Lars Immisch, lars@ibp.de
+    noboost branch

--- a/examples/custom_schema.cpp
+++ b/examples/custom_schema.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
         while (results.popError(error)) {
             cerr << "Error #" << errorNum << std::endl;
             cerr << "  ";
-            BOOST_FOREACH( const std::string contextElement, error.context ) {
+			for( const std::string contextElement : error.context ) {
                 cerr << contextElement << " ";
             }
             cerr << endl;

--- a/examples/custom_schema.cpp
+++ b/examples/custom_schema.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
         while (results.popError(error)) {
             cerr << "Error #" << errorNum << std::endl;
             cerr << "  ";
-			for( const std::string contextElement : error.context ) {
+            for( const std::string contextElement : error.context ) {
                 cerr << contextElement << " ";
             }
             cerr << endl;

--- a/include/compat/optional.hpp
+++ b/include/compat/optional.hpp
@@ -1,0 +1,1042 @@
+// Copyright (C) 2011 - 2012 Andrzej Krzemienski.
+//
+// Use, modification, and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// The idea and interface is based on Boost.Optional library
+// authored by Fernando Luis Cacciola Carballal
+
+# ifndef ___OPTIONAL_HPP___
+# define ___OPTIONAL_HPP___
+
+# include <utility>
+# include <type_traits>
+# include <initializer_list>
+# include <cassert>
+# include <functional>
+# include <string>
+# include <stdexcept>
+
+# define TR2_OPTIONAL_REQUIRES(...) typename enable_if<__VA_ARGS__::value, bool>::type = false
+
+# if defined __GNUC__ // NOTE: GNUC is also defined for Clang
+#   if (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)
+#     define TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+#   elif (__GNUC__ > 4)
+#     define TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+#   endif
+#
+#   if (__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)
+#     define TR2_OPTIONAL_GCC_4_7_AND_HIGHER___
+#   elif (__GNUC__ > 4)
+#     define TR2_OPTIONAL_GCC_4_7_AND_HIGHER___
+#   endif
+#
+#   if (__GNUC__ == 4) && (__GNUC_MINOR__ == 8) && (__GNUC_PATCHLEVEL__ >= 1)
+#     define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   elif (__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)
+#     define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   elif (__GNUC__ > 4)
+#     define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   endif
+# endif
+#
+# if defined __clang_major__
+#   if (__clang_major__ == 3 && __clang_minor__ >= 5)
+#     define TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#   elif (__clang_major__ > 3)
+#     define TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#   endif
+#   if defined TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#     define TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+#   elif (__clang_major__ == 3 && __clang_minor__ == 4 && __clang_patchlevel__ >= 2)
+#     define TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+#   endif
+# endif
+#
+# if defined _MSC_VER
+#   if (_MSC_VER >= 1900)
+#     define TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#   endif
+# endif
+
+# if defined __clang__
+#   if (__clang_major__ > 2) || (__clang_major__ == 2) && (__clang_minor__ >= 9)
+#     define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+#   else
+#     define OPTIONAL_HAS_THIS_RVALUE_REFS 0
+#   endif
+# elif defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#   define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+# else
+#   define OPTIONAL_HAS_THIS_RVALUE_REFS 0
+# endif
+
+
+# if defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#   define OPTIONAL_HAS_CONSTEXPR_INIT_LIST 1
+#   define OPTIONAL_CONSTEXPR_INIT_LIST constexpr
+# else
+#   define OPTIONAL_HAS_CONSTEXPR_INIT_LIST 0
+#   define OPTIONAL_CONSTEXPR_INIT_LIST
+# endif
+
+# if defined TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_ && (defined __cplusplus) && (__cplusplus != 201103L)
+#   define OPTIONAL_HAS_MOVE_ACCESSORS 1
+# else
+#   define OPTIONAL_HAS_MOVE_ACCESSORS 0
+# endif
+
+# // In C++11 constexpr implies const, so we need to make non-const members also non-constexpr
+# if (defined __cplusplus) && (__cplusplus == 201103L)
+#   define OPTIONAL_MUTABLE_CONSTEXPR
+# else
+#   define OPTIONAL_MUTABLE_CONSTEXPR constexpr
+# endif
+
+namespace std{
+
+	namespace experimental{
+
+		// BEGIN workaround for missing is_trivially_destructible
+# if defined TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+		// leave it: it is already there
+# elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+		// leave it: it is already there
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+		// leave it: it is already there
+# elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
+		// leave it: the user doesn't want it
+# else
+		template <typename T>
+		using is_trivially_destructible = std::has_trivial_destructor<T>;
+# endif
+		// END workaround for missing is_trivially_destructible
+
+# if (defined TR2_OPTIONAL_GCC_4_7_AND_HIGHER___)
+		// leave it; our metafunctions are already defined.
+# elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+		// leave it; our metafunctions are already defined.
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+		// leave it: it is already there
+# elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
+		// leave it: the user doesn't want it
+# else
+
+
+		// workaround for missing traits in GCC and CLANG
+		template <class T>
+		struct is_nothrow_move_constructible
+		{
+			constexpr static bool value = std::is_nothrow_constructible<T, T&&>::value;
+		};
+
+
+		template <class T, class U>
+		struct is_assignable
+		{
+			template <class X, class Y>
+			constexpr static bool has_assign(...) { return false; }
+
+			template <class X, class Y, size_t S = sizeof((std::declval<X>() = std::declval<Y>(), true)) >
+			// the comma operator is necessary for the cases where operator= returns void
+			constexpr static bool has_assign(bool) { return true; }
+
+			constexpr static bool value = has_assign<T, U>(true);
+		};
+
+
+		template <class T>
+		struct is_nothrow_move_assignable
+		{
+			template <class X, bool has_any_move_assign>
+			struct has_nothrow_move_assign {
+    constexpr static bool value = false;
+			};
+
+			template <class X>
+			struct has_nothrow_move_assign<X, true> {
+    constexpr static bool value = noexcept( std::declval<X&>() = std::declval<X&&>() );
+			};
+
+			constexpr static bool value = has_nothrow_move_assign<T, is_assignable<T&, T&&>::value>::value;
+		};
+		// end workaround
+
+
+# endif
+
+
+
+		// 20.5.4, optional for object types
+		template <class T> class optional;
+
+		// 20.5.5, optional for lvalue reference types
+		template <class T> class optional<T&>;
+
+
+		// workaround: std utility functions aren't constexpr yet
+		template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type& t) noexcept
+		{
+			return static_cast<T&&>(t);
+		}
+
+		template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type&& t) noexcept
+		{
+			static_assert(!std::is_lvalue_reference<T>::value, "!!");
+			return static_cast<T&&>(t);
+		}
+
+		template <class T> inline constexpr typename std::remove_reference<T>::type&& constexpr_move(T&& t) noexcept
+		{
+			return static_cast<typename std::remove_reference<T>::type&&>(t);
+		}
+
+
+#if defined NDEBUG
+# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
+#else
+# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : ([]{assert(!#CHECK);}(), (EXPR)))
+#endif
+
+
+		namespace detail_
+		{
+
+			// static_addressof: a constexpr version of addressof
+			template <typename T>
+			struct has_overloaded_addressof
+			{
+				template <class X>
+				constexpr static bool has_overload(...) { return false; }
+
+				template <class X, size_t S = sizeof(std::declval<X&>().operator&()) >
+				constexpr static bool has_overload(bool) { return true; }
+
+				constexpr static bool value = has_overload<T>(true);
+			};
+
+			template <typename T, TR2_OPTIONAL_REQUIRES(!has_overloaded_addressof<T>)>
+			constexpr T* static_addressof(T& ref)
+			{
+				return &ref;
+			}
+
+			template <typename T, TR2_OPTIONAL_REQUIRES(has_overloaded_addressof<T>)>
+			T* static_addressof(T& ref)
+			{
+				return std::addressof(ref);
+			}
+
+
+			// the call to convert<A>(b) has return type A and converts b to type A iff b decltype(b) is implicitly convertible to A
+			template <class U>
+			constexpr U convert(U v) { return v; }
+
+		} // namespace detail
+
+
+		constexpr struct trivial_init_t{} trivial_init{};
+
+
+		// 20.5.6, In-place construction
+		constexpr struct in_place_t{} in_place{};
+
+
+		// 20.5.7, Disengaged state indicator
+		struct nullopt_t
+		{
+			struct init{};
+			constexpr explicit nullopt_t(init){}
+		};
+		constexpr nullopt_t nullopt{nullopt_t::init()};
+
+
+		// 20.5.8, class bad_optional_access
+		class bad_optional_access : public logic_error {
+		public:
+			explicit bad_optional_access(const string& what_arg) : logic_error{what_arg} {}
+			explicit bad_optional_access(const char* what_arg) : logic_error{what_arg} {}
+		};
+
+
+		template <class T>
+		union storage_t
+		{
+			unsigned char dummy_;
+			T value_;
+
+			constexpr storage_t( trivial_init_t ) noexcept : dummy_() {};
+
+			template <class... Args>
+			constexpr storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
+
+			~storage_t(){}
+		};
+
+
+		template <class T>
+		union constexpr_storage_t
+		{
+			unsigned char dummy_;
+			T value_;
+
+			constexpr constexpr_storage_t( trivial_init_t ) noexcept : dummy_() {};
+
+			template <class... Args>
+			constexpr constexpr_storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
+
+			~constexpr_storage_t() = default;
+		};
+
+
+		template <class T>
+		struct optional_base
+		{
+			bool init_;
+			storage_t<T> storage_;
+
+			constexpr optional_base() noexcept : init_(false), storage_(trivial_init) {};
+
+			explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
+
+			explicit constexpr optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
+
+			template <class... Args> explicit optional_base(in_place_t, Args&&... args)
+			: init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+			template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+			explicit optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
+			: init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+			~optional_base() { if (init_) storage_.value_.T::~T(); }
+		};
+
+
+		template <class T>
+		struct constexpr_optional_base
+		{
+			bool init_;
+			constexpr_storage_t<T> storage_;
+
+			constexpr constexpr_optional_base() noexcept : init_(false), storage_(trivial_init) {};
+
+			explicit constexpr constexpr_optional_base(const T& v) : init_(true), storage_(v) {}
+
+			explicit constexpr constexpr_optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
+
+			template <class... Args> explicit constexpr constexpr_optional_base(in_place_t, Args&&... args)
+			: init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+			template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+			OPTIONAL_CONSTEXPR_INIT_LIST explicit constexpr_optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
+			: init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+			~constexpr_optional_base() = default;
+		};
+
+		template <class T>
+		using OptionalBase = typename std::conditional<
+		is_trivially_destructible<T>::value,
+		constexpr_optional_base<typename std::remove_const<T>::type>,
+		optional_base<typename std::remove_const<T>::type>
+		>::type;
+
+
+
+		template <class T>
+		class optional : private OptionalBase<T>
+		{
+			static_assert( !std::is_same<typename std::decay<T>::type, nullopt_t>::value, "bad T" );
+			static_assert( !std::is_same<typename std::decay<T>::type, in_place_t>::value, "bad T" );
+
+
+			constexpr bool initialized() const noexcept { return OptionalBase<T>::init_; }
+			typename std::remove_const<T>::type* dataptr() {  return std::addressof(OptionalBase<T>::storage_.value_); }
+			constexpr const T* dataptr() const { return detail_::static_addressof(OptionalBase<T>::storage_.value_); }
+
+# if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
+			constexpr const T& contained_val() const& { return OptionalBase<T>::storage_.value_; }
+#   if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+			OPTIONAL_MUTABLE_CONSTEXPR T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
+			OPTIONAL_MUTABLE_CONSTEXPR T& contained_val() & { return OptionalBase<T>::storage_.value_; }
+#   else
+			T& contained_val() & { return OptionalBase<T>::storage_.value_; }
+			T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
+#   endif
+# else
+			constexpr const T& contained_val() const { return OptionalBase<T>::storage_.value_; }
+			T& contained_val() { return OptionalBase<T>::storage_.value_; }
+# endif
+
+			void clear() noexcept {
+    if (initialized()) dataptr()->T::~T();
+    OptionalBase<T>::init_ = false;
+			}
+
+			template <class... Args>
+			void initialize(Args&&... args) noexcept(noexcept(T(std::forward<Args>(args)...)))
+			{
+    assert(!OptionalBase<T>::init_);
+    ::new (static_cast<void*>(dataptr())) T(std::forward<Args>(args)...);
+    OptionalBase<T>::init_ = true;
+			}
+
+			template <class U, class... Args>
+			void initialize(std::initializer_list<U> il, Args&&... args) noexcept(noexcept(T(il, std::forward<Args>(args)...)))
+			{
+    assert(!OptionalBase<T>::init_);
+    ::new (static_cast<void*>(dataptr())) T(il, std::forward<Args>(args)...);
+    OptionalBase<T>::init_ = true;
+			}
+
+		public:
+			typedef T value_type;
+
+			// 20.5.5.1, constructors
+			constexpr optional() noexcept : OptionalBase<T>()  {};
+			constexpr optional(nullopt_t) noexcept : OptionalBase<T>() {};
+
+			optional(const optional& rhs)
+			: OptionalBase<T>()
+			{
+    if (rhs.initialized()) {
+		::new (static_cast<void*>(dataptr())) T(*rhs);
+		OptionalBase<T>::init_ = true;
+	}
+			}
+
+			optional(optional&& rhs) noexcept(is_nothrow_move_constructible<T>::value)
+			: OptionalBase<T>()
+			{
+    if (rhs.initialized()) {
+		::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
+		OptionalBase<T>::init_ = true;
+	}
+			}
+
+			constexpr optional(const T& v) : OptionalBase<T>(v) {}
+
+			constexpr optional(T&& v) : OptionalBase<T>(constexpr_move(v)) {}
+
+			template <class... Args>
+			explicit constexpr optional(in_place_t, Args&&... args)
+			: OptionalBase<T>(in_place_t{}, constexpr_forward<Args>(args)...) {}
+
+			template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+			OPTIONAL_CONSTEXPR_INIT_LIST explicit optional(in_place_t, std::initializer_list<U> il, Args&&... args)
+			: OptionalBase<T>(in_place_t{}, il, constexpr_forward<Args>(args)...) {}
+
+			// 20.5.4.2, Destructor
+			~optional() = default;
+
+			// 20.5.4.3, assignment
+			optional& operator=(nullopt_t) noexcept
+			{
+    clear();
+    return *this;
+			}
+
+			optional& operator=(const optional& rhs)
+			{
+    if      (initialized() == true  && rhs.initialized() == false) clear();
+	else if (initialized() == false && rhs.initialized() == true)  initialize(*rhs);
+	else if (initialized() == true  && rhs.initialized() == true)  contained_val() = *rhs;
+    return *this;
+			}
+
+			optional& operator=(optional&& rhs)
+			noexcept(is_nothrow_move_assignable<T>::value && is_nothrow_move_constructible<T>::value)
+			{
+    if      (initialized() == true  && rhs.initialized() == false) clear();
+		else if (initialized() == false && rhs.initialized() == true)  initialize(std::move(*rhs));
+			else if (initialized() == true  && rhs.initialized() == true)  contained_val() = std::move(*rhs);
+    return *this;
+			}
+
+			template <class U>
+			auto operator=(U&& v)
+			-> typename enable_if
+			<
+			is_same<typename decay<U>::type, T>::value,
+			optional&
+			>::type
+			{
+    if (initialized()) { contained_val() = std::forward<U>(v); }
+	else               { initialize(std::forward<U>(v));  }
+    return *this;
+			}
+
+
+			template <class... Args>
+			void emplace(Args&&... args)
+			{
+    clear();
+    initialize(std::forward<Args>(args)...);
+			}
+
+			template <class U, class... Args>
+			void emplace(initializer_list<U> il, Args&&... args)
+			{
+    clear();
+    initialize<U, Args...>(il, std::forward<Args>(args)...);
+			}
+
+			// 20.5.4.4, Swap
+			void swap(optional<T>& rhs) noexcept(is_nothrow_move_constructible<T>::value && noexcept(swap(declval<T&>(), declval<T&>())))
+			{
+    if      (initialized() == true  && rhs.initialized() == false) { rhs.initialize(std::move(**this)); clear(); }
+	else if (initialized() == false && rhs.initialized() == true)  { initialize(std::move(*rhs)); rhs.clear(); }
+	else if (initialized() == true  && rhs.initialized() == true)  { using std::swap; swap(**this, *rhs); }
+			}
+
+			// 20.5.4.5, Observers
+
+			explicit constexpr operator bool() const noexcept { return initialized(); }
+
+			constexpr T const* operator ->() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), dataptr());
+			}
+
+# if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+
+			OPTIONAL_MUTABLE_CONSTEXPR T* operator ->() {
+    assert (initialized());
+    return dataptr();
+			}
+
+			constexpr T const& operator *() const& {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
+			}
+
+			OPTIONAL_MUTABLE_CONSTEXPR T& operator *() & {
+    assert (initialized());
+    return contained_val();
+			}
+
+			OPTIONAL_MUTABLE_CONSTEXPR T&& operator *() && {
+    assert (initialized());
+    return constexpr_move(contained_val());
+			}
+
+			constexpr T const& value() const& {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+			}
+
+			OPTIONAL_MUTABLE_CONSTEXPR T& value() & {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+			}
+
+			OPTIONAL_MUTABLE_CONSTEXPR T&& value() && {
+    if (!initialized()) throw bad_optional_access("bad optional access");
+		return std::move(contained_val());
+			}
+
+# else
+
+			T* operator ->() {
+    assert (initialized());
+    return dataptr();
+			}
+
+			constexpr T const& operator *() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
+			}
+
+			T& operator *() {
+    assert (initialized());
+    return contained_val();
+			}
+
+			constexpr T const& value() const {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+			}
+
+			T& value() {
+    return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
+			}
+
+# endif
+
+# if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
+
+			template <class V>
+			constexpr T value_or(V&& v) const&
+			{
+    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+			}
+
+#   if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+
+			template <class V>
+			OPTIONAL_MUTABLE_CONSTEXPR T value_or(V&& v) &&
+			{
+    return *this ? constexpr_move(const_cast<optional<T>&>(*this).contained_val()) : detail_::convert<T>(constexpr_forward<V>(v));
+			}
+
+#   else
+
+			template <class V>
+			T value_or(V&& v) &&
+			{
+    return *this ? constexpr_move(const_cast<optional<T>&>(*this).contained_val()) : detail_::convert<T>(constexpr_forward<V>(v));
+			}
+
+#   endif
+
+# else
+
+			template <class V>
+			constexpr T value_or(V&& v) const
+			{
+    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+			}
+
+# endif
+
+		};
+
+
+		template <class T>
+		class optional<T&>
+		{
+			static_assert( !std::is_same<T, nullopt_t>::value, "bad T" );
+			static_assert( !std::is_same<T, in_place_t>::value, "bad T" );
+			T* ref;
+
+		public:
+
+			// 20.5.5.1, construction/destruction
+			constexpr optional() noexcept : ref(nullptr) {}
+
+			constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
+
+			constexpr optional(T& v) noexcept : ref(detail_::static_addressof(v)) {}
+
+			optional(T&&) = delete;
+
+			constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}
+
+			explicit constexpr optional(in_place_t, T& v) noexcept : ref(detail_::static_addressof(v)) {}
+
+			explicit optional(in_place_t, T&&) = delete;
+
+			~optional() = default;
+
+			// 20.5.5.2, mutation
+			optional& operator=(nullopt_t) noexcept {
+    ref = nullptr;
+    return *this;
+			}
+
+			// optional& operator=(const optional& rhs) noexcept {
+			// ref = rhs.ref;
+			// return *this;
+			// }
+
+			// optional& operator=(optional&& rhs) noexcept {
+			// ref = rhs.ref;
+			// return *this;
+			// }
+
+			template <typename U>
+			auto operator=(U&& rhs) noexcept
+			-> typename enable_if
+			<
+			is_same<typename decay<U>::type, optional<T&>>::value,
+			optional&
+			>::type
+			{
+    ref = rhs.ref;
+    return *this;
+			}
+
+			template <typename U>
+			auto operator=(U&& rhs) noexcept
+			-> typename enable_if
+			<
+			!is_same<typename decay<U>::type, optional<T&>>::value,
+			optional&
+			>::type
+			= delete;
+
+			void emplace(T& v) noexcept {
+    ref = detail_::static_addressof(v);
+			}
+
+			void emplace(T&&) = delete;
+
+
+			void swap(optional<T&>& rhs) noexcept
+			{
+    std::swap(ref, rhs.ref);
+			}
+
+			// 20.5.5.3, observers
+			constexpr T* operator->() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, ref);
+			}
+
+			constexpr T& operator*() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, *ref);
+			}
+
+			constexpr T& value() const {
+    return ref ? *ref : (throw bad_optional_access("bad optional access"), *ref);
+			}
+
+			explicit constexpr operator bool() const noexcept {
+    return ref != nullptr;
+			}
+
+			template <class V>
+			constexpr typename decay<T>::type value_or(V&& v) const
+			{
+    return *this ? **this : detail_::convert<typename decay<T>::type>(constexpr_forward<V>(v));
+			}
+		};
+
+
+		template <class T>
+		class optional<T&&>
+		{
+			static_assert( sizeof(T) == 0, "optional rvalue references disallowed" );
+		};
+
+
+		// 20.5.8, Relational operators
+		template <class T> constexpr bool operator==(const optional<T>& x, const optional<T>& y)
+		{
+			return bool(x) != bool(y) ? false : bool(x) == false ? true : *x == *y;
+		}
+
+		template <class T> constexpr bool operator!=(const optional<T>& x, const optional<T>& y)
+		{
+			return !(x == y);
+		}
+
+		template <class T> constexpr bool operator<(const optional<T>& x, const optional<T>& y)
+		{
+			return (!y) ? false : (!x) ? true : *x < *y;
+		}
+
+		template <class T> constexpr bool operator>(const optional<T>& x, const optional<T>& y)
+		{
+			return (y < x);
+		}
+
+		template <class T> constexpr bool operator<=(const optional<T>& x, const optional<T>& y)
+		{
+			return !(y < x);
+		}
+
+		template <class T> constexpr bool operator>=(const optional<T>& x, const optional<T>& y)
+		{
+			return !(x < y);
+		}
+
+
+		// 20.5.9, Comparison with nullopt
+		template <class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept
+		{
+			return (!x);
+		}
+
+		template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept
+		{
+			return (!x);
+		}
+
+		template <class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept
+		{
+			return bool(x);
+		}
+
+		template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept
+		{
+			return bool(x);
+		}
+
+		template <class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept
+		{
+			return false;
+		}
+
+		template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept
+		{
+			return bool(x);
+		}
+
+		template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept
+		{
+			return (!x);
+		}
+
+		template <class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept
+		{
+			return true;
+		}
+
+		template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept
+		{
+			return bool(x);
+		}
+
+		template <class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept
+		{
+			return false;
+		}
+
+		template <class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept
+		{
+			return true;
+		}
+
+		template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept
+		{
+			return (!x);
+		}
+
+
+
+		// 20.5.10, Comparison with T
+		template <class T> constexpr bool operator==(const optional<T>& x, const T& v)
+		{
+			return bool(x) ? *x == v : false;
+		}
+
+		template <class T> constexpr bool operator==(const T& v, const optional<T>& x)
+		{
+			return bool(x) ? v == *x : false;
+		}
+
+		template <class T> constexpr bool operator!=(const optional<T>& x, const T& v)
+		{
+			return bool(x) ? *x != v : true;
+		}
+
+		template <class T> constexpr bool operator!=(const T& v, const optional<T>& x)
+		{
+			return bool(x) ? v != *x : true;
+		}
+
+		template <class T> constexpr bool operator<(const optional<T>& x, const T& v)
+		{
+			return bool(x) ? *x < v : true;
+		}
+
+		template <class T> constexpr bool operator>(const T& v, const optional<T>& x)
+		{
+			return bool(x) ? v > *x : true;
+		}
+
+		template <class T> constexpr bool operator>(const optional<T>& x, const T& v)
+		{
+			return bool(x) ? *x > v : false;
+		}
+
+		template <class T> constexpr bool operator<(const T& v, const optional<T>& x)
+		{
+			return bool(x) ? v < *x : false;
+		}
+
+		template <class T> constexpr bool operator>=(const optional<T>& x, const T& v)
+		{
+			return bool(x) ? *x >= v : false;
+		}
+
+		template <class T> constexpr bool operator<=(const T& v, const optional<T>& x)
+		{
+			return bool(x) ? v <= *x : false;
+		}
+
+		template <class T> constexpr bool operator<=(const optional<T>& x, const T& v)
+		{
+			return bool(x) ? *x <= v : true;
+		}
+
+		template <class T> constexpr bool operator>=(const T& v, const optional<T>& x)
+		{
+			return bool(x) ? v >= *x : true;
+		}
+
+
+		// Comparison of optional<T&> with T
+		template <class T> constexpr bool operator==(const optional<T&>& x, const T& v)
+		{
+			return bool(x) ? *x == v : false;
+		}
+
+		template <class T> constexpr bool operator==(const T& v, const optional<T&>& x)
+		{
+			return bool(x) ? v == *x : false;
+		}
+
+		template <class T> constexpr bool operator!=(const optional<T&>& x, const T& v)
+		{
+			return bool(x) ? *x != v : true;
+		}
+
+		template <class T> constexpr bool operator!=(const T& v, const optional<T&>& x)
+		{
+			return bool(x) ? v != *x : true;
+		}
+
+		template <class T> constexpr bool operator<(const optional<T&>& x, const T& v)
+		{
+			return bool(x) ? *x < v : true;
+		}
+
+		template <class T> constexpr bool operator>(const T& v, const optional<T&>& x)
+		{
+			return bool(x) ? v > *x : true;
+		}
+
+		template <class T> constexpr bool operator>(const optional<T&>& x, const T& v)
+		{
+			return bool(x) ? *x > v : false;
+		}
+
+		template <class T> constexpr bool operator<(const T& v, const optional<T&>& x)
+		{
+			return bool(x) ? v < *x : false;
+		}
+
+		template <class T> constexpr bool operator>=(const optional<T&>& x, const T& v)
+		{
+			return bool(x) ? *x >= v : false;
+		}
+
+		template <class T> constexpr bool operator<=(const T& v, const optional<T&>& x)
+		{
+			return bool(x) ? v <= *x : false;
+		}
+
+		template <class T> constexpr bool operator<=(const optional<T&>& x, const T& v)
+		{
+			return bool(x) ? *x <= v : true;
+		}
+
+		template <class T> constexpr bool operator>=(const T& v, const optional<T&>& x)
+		{
+			return bool(x) ? v >= *x : true;
+		}
+
+		// Comparison of optional<T const&> with T
+		template <class T> constexpr bool operator==(const optional<const T&>& x, const T& v)
+		{
+			return bool(x) ? *x == v : false;
+		}
+
+		template <class T> constexpr bool operator==(const T& v, const optional<const T&>& x)
+		{
+			return bool(x) ? v == *x : false;
+		}
+
+		template <class T> constexpr bool operator!=(const optional<const T&>& x, const T& v)
+		{
+			return bool(x) ? *x != v : true;
+		}
+
+		template <class T> constexpr bool operator!=(const T& v, const optional<const T&>& x)
+		{
+			return bool(x) ? v != *x : true;
+		}
+
+		template <class T> constexpr bool operator<(const optional<const T&>& x, const T& v)
+		{
+			return bool(x) ? *x < v : true;
+		}
+
+		template <class T> constexpr bool operator>(const T& v, const optional<const T&>& x)
+		{
+			return bool(x) ? v > *x : true;
+		}
+
+		template <class T> constexpr bool operator>(const optional<const T&>& x, const T& v)
+		{
+			return bool(x) ? *x > v : false;
+		}
+
+		template <class T> constexpr bool operator<(const T& v, const optional<const T&>& x)
+		{
+			return bool(x) ? v < *x : false;
+		}
+
+		template <class T> constexpr bool operator>=(const optional<const T&>& x, const T& v)
+		{
+			return bool(x) ? *x >= v : false;
+		}
+
+		template <class T> constexpr bool operator<=(const T& v, const optional<const T&>& x)
+		{
+			return bool(x) ? v <= *x : false;
+		}
+
+		template <class T> constexpr bool operator<=(const optional<const T&>& x, const T& v)
+		{
+			return bool(x) ? *x <= v : true;
+		}
+
+		template <class T> constexpr bool operator>=(const T& v, const optional<const T&>& x)
+		{
+			return bool(x) ? v >= *x : true;
+		}
+
+
+		// 20.5.12, Specialized algorithms
+		template <class T>
+		void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y)))
+		{
+			x.swap(y);
+		}
+		
+		
+		template <class T>
+		constexpr optional<typename decay<T>::type> make_optional(T&& v)
+		{
+			return optional<typename decay<T>::type>(constexpr_forward<T>(v));
+		}
+		
+		template <class X>
+		constexpr optional<X&> make_optional(reference_wrapper<X> v)
+		{
+			return optional<X&>(v.get());
+		}
+		
+		
+	} // namespace experimental
+} // namespace std
+
+namespace std
+{
+	template <typename T>
+	struct hash<std::experimental::optional<T>>
+	{
+		typedef typename hash<T>::result_type result_type;
+		typedef std::experimental::optional<T> argument_type;
+		
+		constexpr result_type operator()(argument_type const& arg) const {
+			return arg ? std::hash<T>{}(*arg) : result_type{};
+		}
+	};
+	
+	template <typename T>
+	struct hash<std::experimental::optional<T&>>
+	{
+		typedef typename hash<T>::result_type result_type;
+		typedef std::experimental::optional<T&> argument_type;
+		
+		constexpr result_type operator()(argument_type const& arg) const {
+			return arg ? std::hash<T>{}(*arg) : result_type{};
+		}
+	};
+}
+
+# undef TR2_OPTIONAL_REQUIRES
+# undef TR2_OPTIONAL_ASSERTED_EXPRESSION
+
+# endif //___OPTIONAL_HPP___

--- a/include/compat/optional.hpp
+++ b/include/compat/optional.hpp
@@ -99,101 +99,101 @@
 
 namespace std{
 
-	namespace experimental{
+    namespace experimental{
 
-		// BEGIN workaround for missing is_trivially_destructible
+        // BEGIN workaround for missing is_trivially_destructible
 # if defined TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
-		// leave it: it is already there
+        // leave it: it is already there
 # elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
-		// leave it: it is already there
+        // leave it: it is already there
 # elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
-		// leave it: it is already there
+        // leave it: it is already there
 # elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
-		// leave it: the user doesn't want it
+        // leave it: the user doesn't want it
 # else
-		template <typename T>
-		using is_trivially_destructible = std::has_trivial_destructor<T>;
+        template <typename T>
+        using is_trivially_destructible = std::has_trivial_destructor<T>;
 # endif
-		// END workaround for missing is_trivially_destructible
+        // END workaround for missing is_trivially_destructible
 
 # if (defined TR2_OPTIONAL_GCC_4_7_AND_HIGHER___)
-		// leave it; our metafunctions are already defined.
+        // leave it; our metafunctions are already defined.
 # elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
-		// leave it; our metafunctions are already defined.
+        // leave it; our metafunctions are already defined.
 # elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
-		// leave it: it is already there
+        // leave it: it is already there
 # elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
-		// leave it: the user doesn't want it
+        // leave it: the user doesn't want it
 # else
 
 
-		// workaround for missing traits in GCC and CLANG
-		template <class T>
-		struct is_nothrow_move_constructible
-		{
-			constexpr static bool value = std::is_nothrow_constructible<T, T&&>::value;
-		};
+        // workaround for missing traits in GCC and CLANG
+        template <class T>
+        struct is_nothrow_move_constructible
+        {
+            constexpr static bool value = std::is_nothrow_constructible<T, T&&>::value;
+        };
 
 
-		template <class T, class U>
-		struct is_assignable
-		{
-			template <class X, class Y>
-			constexpr static bool has_assign(...) { return false; }
+        template <class T, class U>
+        struct is_assignable
+        {
+            template <class X, class Y>
+            constexpr static bool has_assign(...) { return false; }
 
-			template <class X, class Y, size_t S = sizeof((std::declval<X>() = std::declval<Y>(), true)) >
-			// the comma operator is necessary for the cases where operator= returns void
-			constexpr static bool has_assign(bool) { return true; }
+            template <class X, class Y, size_t S = sizeof((std::declval<X>() = std::declval<Y>(), true)) >
+            // the comma operator is necessary for the cases where operator= returns void
+            constexpr static bool has_assign(bool) { return true; }
 
-			constexpr static bool value = has_assign<T, U>(true);
-		};
+            constexpr static bool value = has_assign<T, U>(true);
+        };
 
 
-		template <class T>
-		struct is_nothrow_move_assignable
-		{
-			template <class X, bool has_any_move_assign>
-			struct has_nothrow_move_assign {
+        template <class T>
+        struct is_nothrow_move_assignable
+        {
+            template <class X, bool has_any_move_assign>
+            struct has_nothrow_move_assign {
     constexpr static bool value = false;
-			};
+            };
 
-			template <class X>
-			struct has_nothrow_move_assign<X, true> {
+            template <class X>
+            struct has_nothrow_move_assign<X, true> {
     constexpr static bool value = noexcept( std::declval<X&>() = std::declval<X&&>() );
-			};
+            };
 
-			constexpr static bool value = has_nothrow_move_assign<T, is_assignable<T&, T&&>::value>::value;
-		};
-		// end workaround
+            constexpr static bool value = has_nothrow_move_assign<T, is_assignable<T&, T&&>::value>::value;
+        };
+        // end workaround
 
 
 # endif
 
 
 
-		// 20.5.4, optional for object types
-		template <class T> class optional;
+        // 20.5.4, optional for object types
+        template <class T> class optional;
 
-		// 20.5.5, optional for lvalue reference types
-		template <class T> class optional<T&>;
+        // 20.5.5, optional for lvalue reference types
+        template <class T> class optional<T&>;
 
 
-		// workaround: std utility functions aren't constexpr yet
-		template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type& t) noexcept
-		{
-			return static_cast<T&&>(t);
-		}
+        // workaround: std utility functions aren't constexpr yet
+        template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type& t) noexcept
+        {
+            return static_cast<T&&>(t);
+        }
 
-		template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type&& t) noexcept
-		{
-			static_assert(!std::is_lvalue_reference<T>::value, "!!");
-			return static_cast<T&&>(t);
-		}
+        template <class T> inline constexpr T&& constexpr_forward(typename std::remove_reference<T>::type&& t) noexcept
+        {
+            static_assert(!std::is_lvalue_reference<T>::value, "!!");
+            return static_cast<T&&>(t);
+        }
 
-		template <class T> inline constexpr typename std::remove_reference<T>::type&& constexpr_move(T&& t) noexcept
-		{
-			return static_cast<typename std::remove_reference<T>::type&&>(t);
-		}
+        template <class T> inline constexpr typename std::remove_reference<T>::type&& constexpr_move(T&& t) noexcept
+        {
+            return static_cast<typename std::remove_reference<T>::type&&>(t);
+        }
 
 
 #if defined NDEBUG
@@ -203,837 +203,837 @@ namespace std{
 #endif
 
 
-		namespace detail_
-		{
+        namespace detail_
+        {
 
-			// static_addressof: a constexpr version of addressof
-			template <typename T>
-			struct has_overloaded_addressof
-			{
-				template <class X>
-				constexpr static bool has_overload(...) { return false; }
+            // static_addressof: a constexpr version of addressof
+            template <typename T>
+            struct has_overloaded_addressof
+            {
+                template <class X>
+                constexpr static bool has_overload(...) { return false; }
 
-				template <class X, size_t S = sizeof(std::declval<X&>().operator&()) >
-				constexpr static bool has_overload(bool) { return true; }
+                template <class X, size_t S = sizeof(std::declval<X&>().operator&()) >
+                constexpr static bool has_overload(bool) { return true; }
 
-				constexpr static bool value = has_overload<T>(true);
-			};
+                constexpr static bool value = has_overload<T>(true);
+            };
 
-			template <typename T, TR2_OPTIONAL_REQUIRES(!has_overloaded_addressof<T>)>
-			constexpr T* static_addressof(T& ref)
-			{
-				return &ref;
-			}
+            template <typename T, TR2_OPTIONAL_REQUIRES(!has_overloaded_addressof<T>)>
+            constexpr T* static_addressof(T& ref)
+            {
+                return &ref;
+            }
 
-			template <typename T, TR2_OPTIONAL_REQUIRES(has_overloaded_addressof<T>)>
-			T* static_addressof(T& ref)
-			{
-				return std::addressof(ref);
-			}
-
-
-			// the call to convert<A>(b) has return type A and converts b to type A iff b decltype(b) is implicitly convertible to A
-			template <class U>
-			constexpr U convert(U v) { return v; }
-
-		} // namespace detail
+            template <typename T, TR2_OPTIONAL_REQUIRES(has_overloaded_addressof<T>)>
+            T* static_addressof(T& ref)
+            {
+                return std::addressof(ref);
+            }
 
 
-		constexpr struct trivial_init_t{} trivial_init{};
+            // the call to convert<A>(b) has return type A and converts b to type A iff b decltype(b) is implicitly convertible to A
+            template <class U>
+            constexpr U convert(U v) { return v; }
+
+        } // namespace detail
 
 
-		// 20.5.6, In-place construction
-		constexpr struct in_place_t{} in_place{};
+        constexpr struct trivial_init_t{} trivial_init{};
 
 
-		// 20.5.7, Disengaged state indicator
-		struct nullopt_t
-		{
-			struct init{};
-			constexpr explicit nullopt_t(init){}
-		};
-		constexpr nullopt_t nullopt{nullopt_t::init()};
+        // 20.5.6, In-place construction
+        constexpr struct in_place_t{} in_place{};
 
 
-		// 20.5.8, class bad_optional_access
-		class bad_optional_access : public logic_error {
-		public:
-			explicit bad_optional_access(const string& what_arg) : logic_error{what_arg} {}
-			explicit bad_optional_access(const char* what_arg) : logic_error{what_arg} {}
-		};
+        // 20.5.7, Disengaged state indicator
+        struct nullopt_t
+        {
+            struct init{};
+            constexpr explicit nullopt_t(init){}
+        };
+        constexpr nullopt_t nullopt{nullopt_t::init()};
 
 
-		template <class T>
-		union storage_t
-		{
-			unsigned char dummy_;
-			T value_;
-
-			constexpr storage_t( trivial_init_t ) noexcept : dummy_() {};
-
-			template <class... Args>
-			constexpr storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
-
-			~storage_t(){}
-		};
+        // 20.5.8, class bad_optional_access
+        class bad_optional_access : public logic_error {
+        public:
+            explicit bad_optional_access(const string& what_arg) : logic_error{what_arg} {}
+            explicit bad_optional_access(const char* what_arg) : logic_error{what_arg} {}
+        };
 
 
-		template <class T>
-		union constexpr_storage_t
-		{
-			unsigned char dummy_;
-			T value_;
+        template <class T>
+        union storage_t
+        {
+            unsigned char dummy_;
+            T value_;
 
-			constexpr constexpr_storage_t( trivial_init_t ) noexcept : dummy_() {};
+            constexpr storage_t( trivial_init_t ) noexcept : dummy_() {};
 
-			template <class... Args>
-			constexpr constexpr_storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
+            template <class... Args>
+            constexpr storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
 
-			~constexpr_storage_t() = default;
-		};
-
-
-		template <class T>
-		struct optional_base
-		{
-			bool init_;
-			storage_t<T> storage_;
-
-			constexpr optional_base() noexcept : init_(false), storage_(trivial_init) {};
-
-			explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
-
-			explicit constexpr optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
-
-			template <class... Args> explicit optional_base(in_place_t, Args&&... args)
-			: init_(true), storage_(constexpr_forward<Args>(args)...) {}
-
-			template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
-			explicit optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
-			: init_(true), storage_(il, std::forward<Args>(args)...) {}
-
-			~optional_base() { if (init_) storage_.value_.T::~T(); }
-		};
+            ~storage_t(){}
+        };
 
 
-		template <class T>
-		struct constexpr_optional_base
-		{
-			bool init_;
-			constexpr_storage_t<T> storage_;
+        template <class T>
+        union constexpr_storage_t
+        {
+            unsigned char dummy_;
+            T value_;
 
-			constexpr constexpr_optional_base() noexcept : init_(false), storage_(trivial_init) {};
+            constexpr constexpr_storage_t( trivial_init_t ) noexcept : dummy_() {};
 
-			explicit constexpr constexpr_optional_base(const T& v) : init_(true), storage_(v) {}
+            template <class... Args>
+            constexpr constexpr_storage_t( Args&&... args ) : value_(constexpr_forward<Args>(args)...) {}
 
-			explicit constexpr constexpr_optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
-
-			template <class... Args> explicit constexpr constexpr_optional_base(in_place_t, Args&&... args)
-			: init_(true), storage_(constexpr_forward<Args>(args)...) {}
-
-			template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
-			OPTIONAL_CONSTEXPR_INIT_LIST explicit constexpr_optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
-			: init_(true), storage_(il, std::forward<Args>(args)...) {}
-
-			~constexpr_optional_base() = default;
-		};
-
-		template <class T>
-		using OptionalBase = typename std::conditional<
-		is_trivially_destructible<T>::value,
-		constexpr_optional_base<typename std::remove_const<T>::type>,
-		optional_base<typename std::remove_const<T>::type>
-		>::type;
+            ~constexpr_storage_t() = default;
+        };
 
 
+        template <class T>
+        struct optional_base
+        {
+            bool init_;
+            storage_t<T> storage_;
 
-		template <class T>
-		class optional : private OptionalBase<T>
-		{
-			static_assert( !std::is_same<typename std::decay<T>::type, nullopt_t>::value, "bad T" );
-			static_assert( !std::is_same<typename std::decay<T>::type, in_place_t>::value, "bad T" );
+            constexpr optional_base() noexcept : init_(false), storage_(trivial_init) {};
+
+            explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
+
+            explicit constexpr optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
+
+            template <class... Args> explicit optional_base(in_place_t, Args&&... args)
+            : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+            template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+            explicit optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
+            : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+            ~optional_base() { if (init_) storage_.value_.T::~T(); }
+        };
 
 
-			constexpr bool initialized() const noexcept { return OptionalBase<T>::init_; }
-			typename std::remove_const<T>::type* dataptr() {  return std::addressof(OptionalBase<T>::storage_.value_); }
-			constexpr const T* dataptr() const { return detail_::static_addressof(OptionalBase<T>::storage_.value_); }
+        template <class T>
+        struct constexpr_optional_base
+        {
+            bool init_;
+            constexpr_storage_t<T> storage_;
+
+            constexpr constexpr_optional_base() noexcept : init_(false), storage_(trivial_init) {};
+
+            explicit constexpr constexpr_optional_base(const T& v) : init_(true), storage_(v) {}
+
+            explicit constexpr constexpr_optional_base(T&& v) : init_(true), storage_(constexpr_move(v)) {}
+
+            template <class... Args> explicit constexpr constexpr_optional_base(in_place_t, Args&&... args)
+            : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+            template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+            OPTIONAL_CONSTEXPR_INIT_LIST explicit constexpr_optional_base(in_place_t, std::initializer_list<U> il, Args&&... args)
+            : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+            ~constexpr_optional_base() = default;
+        };
+
+        template <class T>
+        using OptionalBase = typename std::conditional<
+        is_trivially_destructible<T>::value,
+        constexpr_optional_base<typename std::remove_const<T>::type>,
+        optional_base<typename std::remove_const<T>::type>
+        >::type;
+
+
+
+        template <class T>
+        class optional : private OptionalBase<T>
+        {
+            static_assert( !std::is_same<typename std::decay<T>::type, nullopt_t>::value, "bad T" );
+            static_assert( !std::is_same<typename std::decay<T>::type, in_place_t>::value, "bad T" );
+
+
+            constexpr bool initialized() const noexcept { return OptionalBase<T>::init_; }
+            typename std::remove_const<T>::type* dataptr() {  return std::addressof(OptionalBase<T>::storage_.value_); }
+            constexpr const T* dataptr() const { return detail_::static_addressof(OptionalBase<T>::storage_.value_); }
 
 # if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
-			constexpr const T& contained_val() const& { return OptionalBase<T>::storage_.value_; }
+            constexpr const T& contained_val() const& { return OptionalBase<T>::storage_.value_; }
 #   if OPTIONAL_HAS_MOVE_ACCESSORS == 1
-			OPTIONAL_MUTABLE_CONSTEXPR T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
-			OPTIONAL_MUTABLE_CONSTEXPR T& contained_val() & { return OptionalBase<T>::storage_.value_; }
+            OPTIONAL_MUTABLE_CONSTEXPR T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
+            OPTIONAL_MUTABLE_CONSTEXPR T& contained_val() & { return OptionalBase<T>::storage_.value_; }
 #   else
-			T& contained_val() & { return OptionalBase<T>::storage_.value_; }
-			T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
+            T& contained_val() & { return OptionalBase<T>::storage_.value_; }
+            T&& contained_val() && { return std::move(OptionalBase<T>::storage_.value_); }
 #   endif
 # else
-			constexpr const T& contained_val() const { return OptionalBase<T>::storage_.value_; }
-			T& contained_val() { return OptionalBase<T>::storage_.value_; }
+            constexpr const T& contained_val() const { return OptionalBase<T>::storage_.value_; }
+            T& contained_val() { return OptionalBase<T>::storage_.value_; }
 # endif
 
-			void clear() noexcept {
+            void clear() noexcept {
     if (initialized()) dataptr()->T::~T();
     OptionalBase<T>::init_ = false;
-			}
+            }
 
-			template <class... Args>
-			void initialize(Args&&... args) noexcept(noexcept(T(std::forward<Args>(args)...)))
-			{
+            template <class... Args>
+            void initialize(Args&&... args) noexcept(noexcept(T(std::forward<Args>(args)...)))
+            {
     assert(!OptionalBase<T>::init_);
     ::new (static_cast<void*>(dataptr())) T(std::forward<Args>(args)...);
     OptionalBase<T>::init_ = true;
-			}
+            }
 
-			template <class U, class... Args>
-			void initialize(std::initializer_list<U> il, Args&&... args) noexcept(noexcept(T(il, std::forward<Args>(args)...)))
-			{
+            template <class U, class... Args>
+            void initialize(std::initializer_list<U> il, Args&&... args) noexcept(noexcept(T(il, std::forward<Args>(args)...)))
+            {
     assert(!OptionalBase<T>::init_);
     ::new (static_cast<void*>(dataptr())) T(il, std::forward<Args>(args)...);
     OptionalBase<T>::init_ = true;
-			}
+            }
 
-		public:
-			typedef T value_type;
+        public:
+            typedef T value_type;
 
-			// 20.5.5.1, constructors
-			constexpr optional() noexcept : OptionalBase<T>()  {};
-			constexpr optional(nullopt_t) noexcept : OptionalBase<T>() {};
+            // 20.5.5.1, constructors
+            constexpr optional() noexcept : OptionalBase<T>()  {};
+            constexpr optional(nullopt_t) noexcept : OptionalBase<T>() {};
 
-			optional(const optional& rhs)
-			: OptionalBase<T>()
-			{
+            optional(const optional& rhs)
+            : OptionalBase<T>()
+            {
     if (rhs.initialized()) {
-		::new (static_cast<void*>(dataptr())) T(*rhs);
-		OptionalBase<T>::init_ = true;
-	}
-			}
+        ::new (static_cast<void*>(dataptr())) T(*rhs);
+        OptionalBase<T>::init_ = true;
+    }
+            }
 
-			optional(optional&& rhs) noexcept(is_nothrow_move_constructible<T>::value)
-			: OptionalBase<T>()
-			{
+            optional(optional&& rhs) noexcept(is_nothrow_move_constructible<T>::value)
+            : OptionalBase<T>()
+            {
     if (rhs.initialized()) {
-		::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
-		OptionalBase<T>::init_ = true;
-	}
-			}
+        ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
+        OptionalBase<T>::init_ = true;
+    }
+            }
 
-			constexpr optional(const T& v) : OptionalBase<T>(v) {}
+            constexpr optional(const T& v) : OptionalBase<T>(v) {}
 
-			constexpr optional(T&& v) : OptionalBase<T>(constexpr_move(v)) {}
+            constexpr optional(T&& v) : OptionalBase<T>(constexpr_move(v)) {}
 
-			template <class... Args>
-			explicit constexpr optional(in_place_t, Args&&... args)
-			: OptionalBase<T>(in_place_t{}, constexpr_forward<Args>(args)...) {}
+            template <class... Args>
+            explicit constexpr optional(in_place_t, Args&&... args)
+            : OptionalBase<T>(in_place_t{}, constexpr_forward<Args>(args)...) {}
 
-			template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
-			OPTIONAL_CONSTEXPR_INIT_LIST explicit optional(in_place_t, std::initializer_list<U> il, Args&&... args)
-			: OptionalBase<T>(in_place_t{}, il, constexpr_forward<Args>(args)...) {}
+            template <class U, class... Args, TR2_OPTIONAL_REQUIRES(is_constructible<T, std::initializer_list<U>>)>
+            OPTIONAL_CONSTEXPR_INIT_LIST explicit optional(in_place_t, std::initializer_list<U> il, Args&&... args)
+            : OptionalBase<T>(in_place_t{}, il, constexpr_forward<Args>(args)...) {}
 
-			// 20.5.4.2, Destructor
-			~optional() = default;
+            // 20.5.4.2, Destructor
+            ~optional() = default;
 
-			// 20.5.4.3, assignment
-			optional& operator=(nullopt_t) noexcept
-			{
+            // 20.5.4.3, assignment
+            optional& operator=(nullopt_t) noexcept
+            {
     clear();
     return *this;
-			}
+            }
 
-			optional& operator=(const optional& rhs)
-			{
+            optional& operator=(const optional& rhs)
+            {
     if      (initialized() == true  && rhs.initialized() == false) clear();
-	else if (initialized() == false && rhs.initialized() == true)  initialize(*rhs);
-	else if (initialized() == true  && rhs.initialized() == true)  contained_val() = *rhs;
+    else if (initialized() == false && rhs.initialized() == true)  initialize(*rhs);
+    else if (initialized() == true  && rhs.initialized() == true)  contained_val() = *rhs;
     return *this;
-			}
+            }
 
-			optional& operator=(optional&& rhs)
-			noexcept(is_nothrow_move_assignable<T>::value && is_nothrow_move_constructible<T>::value)
-			{
+            optional& operator=(optional&& rhs)
+            noexcept(is_nothrow_move_assignable<T>::value && is_nothrow_move_constructible<T>::value)
+            {
     if      (initialized() == true  && rhs.initialized() == false) clear();
-		else if (initialized() == false && rhs.initialized() == true)  initialize(std::move(*rhs));
-			else if (initialized() == true  && rhs.initialized() == true)  contained_val() = std::move(*rhs);
+        else if (initialized() == false && rhs.initialized() == true)  initialize(std::move(*rhs));
+            else if (initialized() == true  && rhs.initialized() == true)  contained_val() = std::move(*rhs);
     return *this;
-			}
+            }
 
-			template <class U>
-			auto operator=(U&& v)
-			-> typename enable_if
-			<
-			is_same<typename decay<U>::type, T>::value,
-			optional&
-			>::type
-			{
+            template <class U>
+            auto operator=(U&& v)
+            -> typename enable_if
+            <
+            is_same<typename decay<U>::type, T>::value,
+            optional&
+            >::type
+            {
     if (initialized()) { contained_val() = std::forward<U>(v); }
-	else               { initialize(std::forward<U>(v));  }
+    else               { initialize(std::forward<U>(v));  }
     return *this;
-			}
+            }
 
 
-			template <class... Args>
-			void emplace(Args&&... args)
-			{
+            template <class... Args>
+            void emplace(Args&&... args)
+            {
     clear();
     initialize(std::forward<Args>(args)...);
-			}
+            }
 
-			template <class U, class... Args>
-			void emplace(initializer_list<U> il, Args&&... args)
-			{
+            template <class U, class... Args>
+            void emplace(initializer_list<U> il, Args&&... args)
+            {
     clear();
     initialize<U, Args...>(il, std::forward<Args>(args)...);
-			}
+            }
 
-			// 20.5.4.4, Swap
-			void swap(optional<T>& rhs) noexcept(is_nothrow_move_constructible<T>::value && noexcept(swap(declval<T&>(), declval<T&>())))
-			{
+            // 20.5.4.4, Swap
+            void swap(optional<T>& rhs) noexcept(is_nothrow_move_constructible<T>::value && noexcept(swap(declval<T&>(), declval<T&>())))
+            {
     if      (initialized() == true  && rhs.initialized() == false) { rhs.initialize(std::move(**this)); clear(); }
-	else if (initialized() == false && rhs.initialized() == true)  { initialize(std::move(*rhs)); rhs.clear(); }
-	else if (initialized() == true  && rhs.initialized() == true)  { using std::swap; swap(**this, *rhs); }
-			}
+    else if (initialized() == false && rhs.initialized() == true)  { initialize(std::move(*rhs)); rhs.clear(); }
+    else if (initialized() == true  && rhs.initialized() == true)  { using std::swap; swap(**this, *rhs); }
+            }
 
-			// 20.5.4.5, Observers
+            // 20.5.4.5, Observers
 
-			explicit constexpr operator bool() const noexcept { return initialized(); }
+            explicit constexpr operator bool() const noexcept { return initialized(); }
 
-			constexpr T const* operator ->() const {
+            constexpr T const* operator ->() const {
     return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), dataptr());
-			}
+            }
 
 # if OPTIONAL_HAS_MOVE_ACCESSORS == 1
 
-			OPTIONAL_MUTABLE_CONSTEXPR T* operator ->() {
+            OPTIONAL_MUTABLE_CONSTEXPR T* operator ->() {
     assert (initialized());
     return dataptr();
-			}
+            }
 
-			constexpr T const& operator *() const& {
+            constexpr T const& operator *() const& {
     return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
-			}
+            }
 
-			OPTIONAL_MUTABLE_CONSTEXPR T& operator *() & {
+            OPTIONAL_MUTABLE_CONSTEXPR T& operator *() & {
     assert (initialized());
     return contained_val();
-			}
+            }
 
-			OPTIONAL_MUTABLE_CONSTEXPR T&& operator *() && {
+            OPTIONAL_MUTABLE_CONSTEXPR T&& operator *() && {
     assert (initialized());
     return constexpr_move(contained_val());
-			}
+            }
 
-			constexpr T const& value() const& {
+            constexpr T const& value() const& {
     return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
-			}
+            }
 
-			OPTIONAL_MUTABLE_CONSTEXPR T& value() & {
+            OPTIONAL_MUTABLE_CONSTEXPR T& value() & {
     return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
-			}
+            }
 
-			OPTIONAL_MUTABLE_CONSTEXPR T&& value() && {
+            OPTIONAL_MUTABLE_CONSTEXPR T&& value() && {
     if (!initialized()) throw bad_optional_access("bad optional access");
-		return std::move(contained_val());
-			}
+        return std::move(contained_val());
+            }
 
 # else
 
-			T* operator ->() {
+            T* operator ->() {
     assert (initialized());
     return dataptr();
-			}
+            }
 
-			constexpr T const& operator *() const {
+            constexpr T const& operator *() const {
     return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
-			}
+            }
 
-			T& operator *() {
+            T& operator *() {
     assert (initialized());
     return contained_val();
-			}
+            }
 
-			constexpr T const& value() const {
+            constexpr T const& value() const {
     return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
-			}
+            }
 
-			T& value() {
+            T& value() {
     return initialized() ? contained_val() : (throw bad_optional_access("bad optional access"), contained_val());
-			}
+            }
 
 # endif
 
 # if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
 
-			template <class V>
-			constexpr T value_or(V&& v) const&
-			{
+            template <class V>
+            constexpr T value_or(V&& v) const&
+            {
     return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
-			}
+            }
 
 #   if OPTIONAL_HAS_MOVE_ACCESSORS == 1
 
-			template <class V>
-			OPTIONAL_MUTABLE_CONSTEXPR T value_or(V&& v) &&
-			{
+            template <class V>
+            OPTIONAL_MUTABLE_CONSTEXPR T value_or(V&& v) &&
+            {
     return *this ? constexpr_move(const_cast<optional<T>&>(*this).contained_val()) : detail_::convert<T>(constexpr_forward<V>(v));
-			}
+            }
 
 #   else
 
-			template <class V>
-			T value_or(V&& v) &&
-			{
+            template <class V>
+            T value_or(V&& v) &&
+            {
     return *this ? constexpr_move(const_cast<optional<T>&>(*this).contained_val()) : detail_::convert<T>(constexpr_forward<V>(v));
-			}
+            }
 
 #   endif
 
 # else
 
-			template <class V>
-			constexpr T value_or(V&& v) const
-			{
+            template <class V>
+            constexpr T value_or(V&& v) const
+            {
     return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
-			}
+            }
 
 # endif
 
-		};
+        };
 
 
-		template <class T>
-		class optional<T&>
-		{
-			static_assert( !std::is_same<T, nullopt_t>::value, "bad T" );
-			static_assert( !std::is_same<T, in_place_t>::value, "bad T" );
-			T* ref;
+        template <class T>
+        class optional<T&>
+        {
+            static_assert( !std::is_same<T, nullopt_t>::value, "bad T" );
+            static_assert( !std::is_same<T, in_place_t>::value, "bad T" );
+            T* ref;
 
-		public:
+        public:
 
-			// 20.5.5.1, construction/destruction
-			constexpr optional() noexcept : ref(nullptr) {}
+            // 20.5.5.1, construction/destruction
+            constexpr optional() noexcept : ref(nullptr) {}
 
-			constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
+            constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
 
-			constexpr optional(T& v) noexcept : ref(detail_::static_addressof(v)) {}
+            constexpr optional(T& v) noexcept : ref(detail_::static_addressof(v)) {}
 
-			optional(T&&) = delete;
+            optional(T&&) = delete;
 
-			constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}
+            constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}
 
-			explicit constexpr optional(in_place_t, T& v) noexcept : ref(detail_::static_addressof(v)) {}
+            explicit constexpr optional(in_place_t, T& v) noexcept : ref(detail_::static_addressof(v)) {}
 
-			explicit optional(in_place_t, T&&) = delete;
+            explicit optional(in_place_t, T&&) = delete;
 
-			~optional() = default;
+            ~optional() = default;
 
-			// 20.5.5.2, mutation
-			optional& operator=(nullopt_t) noexcept {
+            // 20.5.5.2, mutation
+            optional& operator=(nullopt_t) noexcept {
     ref = nullptr;
     return *this;
-			}
+            }
 
-			// optional& operator=(const optional& rhs) noexcept {
-			// ref = rhs.ref;
-			// return *this;
-			// }
+            // optional& operator=(const optional& rhs) noexcept {
+            // ref = rhs.ref;
+            // return *this;
+            // }
 
-			// optional& operator=(optional&& rhs) noexcept {
-			// ref = rhs.ref;
-			// return *this;
-			// }
+            // optional& operator=(optional&& rhs) noexcept {
+            // ref = rhs.ref;
+            // return *this;
+            // }
 
-			template <typename U>
-			auto operator=(U&& rhs) noexcept
-			-> typename enable_if
-			<
-			is_same<typename decay<U>::type, optional<T&>>::value,
-			optional&
-			>::type
-			{
+            template <typename U>
+            auto operator=(U&& rhs) noexcept
+            -> typename enable_if
+            <
+            is_same<typename decay<U>::type, optional<T&>>::value,
+            optional&
+            >::type
+            {
     ref = rhs.ref;
     return *this;
-			}
+            }
 
-			template <typename U>
-			auto operator=(U&& rhs) noexcept
-			-> typename enable_if
-			<
-			!is_same<typename decay<U>::type, optional<T&>>::value,
-			optional&
-			>::type
-			= delete;
+            template <typename U>
+            auto operator=(U&& rhs) noexcept
+            -> typename enable_if
+            <
+            !is_same<typename decay<U>::type, optional<T&>>::value,
+            optional&
+            >::type
+            = delete;
 
-			void emplace(T& v) noexcept {
+            void emplace(T& v) noexcept {
     ref = detail_::static_addressof(v);
-			}
+            }
 
-			void emplace(T&&) = delete;
+            void emplace(T&&) = delete;
 
 
-			void swap(optional<T&>& rhs) noexcept
-			{
+            void swap(optional<T&>& rhs) noexcept
+            {
     std::swap(ref, rhs.ref);
-			}
+            }
 
-			// 20.5.5.3, observers
-			constexpr T* operator->() const {
+            // 20.5.5.3, observers
+            constexpr T* operator->() const {
     return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, ref);
-			}
+            }
 
-			constexpr T& operator*() const {
+            constexpr T& operator*() const {
     return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, *ref);
-			}
+            }
 
-			constexpr T& value() const {
+            constexpr T& value() const {
     return ref ? *ref : (throw bad_optional_access("bad optional access"), *ref);
-			}
+            }
 
-			explicit constexpr operator bool() const noexcept {
+            explicit constexpr operator bool() const noexcept {
     return ref != nullptr;
-			}
+            }
 
-			template <class V>
-			constexpr typename decay<T>::type value_or(V&& v) const
-			{
+            template <class V>
+            constexpr typename decay<T>::type value_or(V&& v) const
+            {
     return *this ? **this : detail_::convert<typename decay<T>::type>(constexpr_forward<V>(v));
-			}
-		};
+            }
+        };
 
 
-		template <class T>
-		class optional<T&&>
-		{
-			static_assert( sizeof(T) == 0, "optional rvalue references disallowed" );
-		};
+        template <class T>
+        class optional<T&&>
+        {
+            static_assert( sizeof(T) == 0, "optional rvalue references disallowed" );
+        };
 
 
-		// 20.5.8, Relational operators
-		template <class T> constexpr bool operator==(const optional<T>& x, const optional<T>& y)
-		{
-			return bool(x) != bool(y) ? false : bool(x) == false ? true : *x == *y;
-		}
+        // 20.5.8, Relational operators
+        template <class T> constexpr bool operator==(const optional<T>& x, const optional<T>& y)
+        {
+            return bool(x) != bool(y) ? false : bool(x) == false ? true : *x == *y;
+        }
 
-		template <class T> constexpr bool operator!=(const optional<T>& x, const optional<T>& y)
-		{
-			return !(x == y);
-		}
+        template <class T> constexpr bool operator!=(const optional<T>& x, const optional<T>& y)
+        {
+            return !(x == y);
+        }
 
-		template <class T> constexpr bool operator<(const optional<T>& x, const optional<T>& y)
-		{
-			return (!y) ? false : (!x) ? true : *x < *y;
-		}
+        template <class T> constexpr bool operator<(const optional<T>& x, const optional<T>& y)
+        {
+            return (!y) ? false : (!x) ? true : *x < *y;
+        }
 
-		template <class T> constexpr bool operator>(const optional<T>& x, const optional<T>& y)
-		{
-			return (y < x);
-		}
+        template <class T> constexpr bool operator>(const optional<T>& x, const optional<T>& y)
+        {
+            return (y < x);
+        }
 
-		template <class T> constexpr bool operator<=(const optional<T>& x, const optional<T>& y)
-		{
-			return !(y < x);
-		}
+        template <class T> constexpr bool operator<=(const optional<T>& x, const optional<T>& y)
+        {
+            return !(y < x);
+        }
 
-		template <class T> constexpr bool operator>=(const optional<T>& x, const optional<T>& y)
-		{
-			return !(x < y);
-		}
-
-
-		// 20.5.9, Comparison with nullopt
-		template <class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept
-		{
-			return (!x);
-		}
-
-		template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept
-		{
-			return (!x);
-		}
-
-		template <class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept
-		{
-			return bool(x);
-		}
-
-		template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept
-		{
-			return bool(x);
-		}
-
-		template <class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept
-		{
-			return false;
-		}
-
-		template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept
-		{
-			return bool(x);
-		}
-
-		template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept
-		{
-			return (!x);
-		}
-
-		template <class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept
-		{
-			return true;
-		}
-
-		template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept
-		{
-			return bool(x);
-		}
-
-		template <class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept
-		{
-			return false;
-		}
-
-		template <class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept
-		{
-			return true;
-		}
-
-		template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept
-		{
-			return (!x);
-		}
+        template <class T> constexpr bool operator>=(const optional<T>& x, const optional<T>& y)
+        {
+            return !(x < y);
+        }
 
 
+        // 20.5.9, Comparison with nullopt
+        template <class T> constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept
+        {
+            return (!x);
+        }
 
-		// 20.5.10, Comparison with T
-		template <class T> constexpr bool operator==(const optional<T>& x, const T& v)
-		{
-			return bool(x) ? *x == v : false;
-		}
+        template <class T> constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept
+        {
+            return (!x);
+        }
 
-		template <class T> constexpr bool operator==(const T& v, const optional<T>& x)
-		{
-			return bool(x) ? v == *x : false;
-		}
+        template <class T> constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept
+        {
+            return bool(x);
+        }
 
-		template <class T> constexpr bool operator!=(const optional<T>& x, const T& v)
-		{
-			return bool(x) ? *x != v : true;
-		}
+        template <class T> constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept
+        {
+            return bool(x);
+        }
 
-		template <class T> constexpr bool operator!=(const T& v, const optional<T>& x)
-		{
-			return bool(x) ? v != *x : true;
-		}
+        template <class T> constexpr bool operator<(const optional<T>&, nullopt_t) noexcept
+        {
+            return false;
+        }
 
-		template <class T> constexpr bool operator<(const optional<T>& x, const T& v)
-		{
-			return bool(x) ? *x < v : true;
-		}
+        template <class T> constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept
+        {
+            return bool(x);
+        }
 
-		template <class T> constexpr bool operator>(const T& v, const optional<T>& x)
-		{
-			return bool(x) ? v > *x : true;
-		}
+        template <class T> constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept
+        {
+            return (!x);
+        }
 
-		template <class T> constexpr bool operator>(const optional<T>& x, const T& v)
-		{
-			return bool(x) ? *x > v : false;
-		}
+        template <class T> constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept
+        {
+            return true;
+        }
 
-		template <class T> constexpr bool operator<(const T& v, const optional<T>& x)
-		{
-			return bool(x) ? v < *x : false;
-		}
+        template <class T> constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept
+        {
+            return bool(x);
+        }
 
-		template <class T> constexpr bool operator>=(const optional<T>& x, const T& v)
-		{
-			return bool(x) ? *x >= v : false;
-		}
+        template <class T> constexpr bool operator>(nullopt_t, const optional<T>&) noexcept
+        {
+            return false;
+        }
 
-		template <class T> constexpr bool operator<=(const T& v, const optional<T>& x)
-		{
-			return bool(x) ? v <= *x : false;
-		}
+        template <class T> constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept
+        {
+            return true;
+        }
 
-		template <class T> constexpr bool operator<=(const optional<T>& x, const T& v)
-		{
-			return bool(x) ? *x <= v : true;
-		}
-
-		template <class T> constexpr bool operator>=(const T& v, const optional<T>& x)
-		{
-			return bool(x) ? v >= *x : true;
-		}
-
-
-		// Comparison of optional<T&> with T
-		template <class T> constexpr bool operator==(const optional<T&>& x, const T& v)
-		{
-			return bool(x) ? *x == v : false;
-		}
-
-		template <class T> constexpr bool operator==(const T& v, const optional<T&>& x)
-		{
-			return bool(x) ? v == *x : false;
-		}
-
-		template <class T> constexpr bool operator!=(const optional<T&>& x, const T& v)
-		{
-			return bool(x) ? *x != v : true;
-		}
-
-		template <class T> constexpr bool operator!=(const T& v, const optional<T&>& x)
-		{
-			return bool(x) ? v != *x : true;
-		}
-
-		template <class T> constexpr bool operator<(const optional<T&>& x, const T& v)
-		{
-			return bool(x) ? *x < v : true;
-		}
-
-		template <class T> constexpr bool operator>(const T& v, const optional<T&>& x)
-		{
-			return bool(x) ? v > *x : true;
-		}
-
-		template <class T> constexpr bool operator>(const optional<T&>& x, const T& v)
-		{
-			return bool(x) ? *x > v : false;
-		}
-
-		template <class T> constexpr bool operator<(const T& v, const optional<T&>& x)
-		{
-			return bool(x) ? v < *x : false;
-		}
-
-		template <class T> constexpr bool operator>=(const optional<T&>& x, const T& v)
-		{
-			return bool(x) ? *x >= v : false;
-		}
-
-		template <class T> constexpr bool operator<=(const T& v, const optional<T&>& x)
-		{
-			return bool(x) ? v <= *x : false;
-		}
-
-		template <class T> constexpr bool operator<=(const optional<T&>& x, const T& v)
-		{
-			return bool(x) ? *x <= v : true;
-		}
-
-		template <class T> constexpr bool operator>=(const T& v, const optional<T&>& x)
-		{
-			return bool(x) ? v >= *x : true;
-		}
-
-		// Comparison of optional<T const&> with T
-		template <class T> constexpr bool operator==(const optional<const T&>& x, const T& v)
-		{
-			return bool(x) ? *x == v : false;
-		}
-
-		template <class T> constexpr bool operator==(const T& v, const optional<const T&>& x)
-		{
-			return bool(x) ? v == *x : false;
-		}
-
-		template <class T> constexpr bool operator!=(const optional<const T&>& x, const T& v)
-		{
-			return bool(x) ? *x != v : true;
-		}
-
-		template <class T> constexpr bool operator!=(const T& v, const optional<const T&>& x)
-		{
-			return bool(x) ? v != *x : true;
-		}
-
-		template <class T> constexpr bool operator<(const optional<const T&>& x, const T& v)
-		{
-			return bool(x) ? *x < v : true;
-		}
-
-		template <class T> constexpr bool operator>(const T& v, const optional<const T&>& x)
-		{
-			return bool(x) ? v > *x : true;
-		}
-
-		template <class T> constexpr bool operator>(const optional<const T&>& x, const T& v)
-		{
-			return bool(x) ? *x > v : false;
-		}
-
-		template <class T> constexpr bool operator<(const T& v, const optional<const T&>& x)
-		{
-			return bool(x) ? v < *x : false;
-		}
-
-		template <class T> constexpr bool operator>=(const optional<const T&>& x, const T& v)
-		{
-			return bool(x) ? *x >= v : false;
-		}
-
-		template <class T> constexpr bool operator<=(const T& v, const optional<const T&>& x)
-		{
-			return bool(x) ? v <= *x : false;
-		}
-
-		template <class T> constexpr bool operator<=(const optional<const T&>& x, const T& v)
-		{
-			return bool(x) ? *x <= v : true;
-		}
-
-		template <class T> constexpr bool operator>=(const T& v, const optional<const T&>& x)
-		{
-			return bool(x) ? v >= *x : true;
-		}
+        template <class T> constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept
+        {
+            return (!x);
+        }
 
 
-		// 20.5.12, Specialized algorithms
-		template <class T>
-		void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y)))
-		{
-			x.swap(y);
-		}
-		
-		
-		template <class T>
-		constexpr optional<typename decay<T>::type> make_optional(T&& v)
-		{
-			return optional<typename decay<T>::type>(constexpr_forward<T>(v));
-		}
-		
-		template <class X>
-		constexpr optional<X&> make_optional(reference_wrapper<X> v)
-		{
-			return optional<X&>(v.get());
-		}
-		
-		
-	} // namespace experimental
+
+        // 20.5.10, Comparison with T
+        template <class T> constexpr bool operator==(const optional<T>& x, const T& v)
+        {
+            return bool(x) ? *x == v : false;
+        }
+
+        template <class T> constexpr bool operator==(const T& v, const optional<T>& x)
+        {
+            return bool(x) ? v == *x : false;
+        }
+
+        template <class T> constexpr bool operator!=(const optional<T>& x, const T& v)
+        {
+            return bool(x) ? *x != v : true;
+        }
+
+        template <class T> constexpr bool operator!=(const T& v, const optional<T>& x)
+        {
+            return bool(x) ? v != *x : true;
+        }
+
+        template <class T> constexpr bool operator<(const optional<T>& x, const T& v)
+        {
+            return bool(x) ? *x < v : true;
+        }
+
+        template <class T> constexpr bool operator>(const T& v, const optional<T>& x)
+        {
+            return bool(x) ? v > *x : true;
+        }
+
+        template <class T> constexpr bool operator>(const optional<T>& x, const T& v)
+        {
+            return bool(x) ? *x > v : false;
+        }
+
+        template <class T> constexpr bool operator<(const T& v, const optional<T>& x)
+        {
+            return bool(x) ? v < *x : false;
+        }
+
+        template <class T> constexpr bool operator>=(const optional<T>& x, const T& v)
+        {
+            return bool(x) ? *x >= v : false;
+        }
+
+        template <class T> constexpr bool operator<=(const T& v, const optional<T>& x)
+        {
+            return bool(x) ? v <= *x : false;
+        }
+
+        template <class T> constexpr bool operator<=(const optional<T>& x, const T& v)
+        {
+            return bool(x) ? *x <= v : true;
+        }
+
+        template <class T> constexpr bool operator>=(const T& v, const optional<T>& x)
+        {
+            return bool(x) ? v >= *x : true;
+        }
+
+
+        // Comparison of optional<T&> with T
+        template <class T> constexpr bool operator==(const optional<T&>& x, const T& v)
+        {
+            return bool(x) ? *x == v : false;
+        }
+
+        template <class T> constexpr bool operator==(const T& v, const optional<T&>& x)
+        {
+            return bool(x) ? v == *x : false;
+        }
+
+        template <class T> constexpr bool operator!=(const optional<T&>& x, const T& v)
+        {
+            return bool(x) ? *x != v : true;
+        }
+
+        template <class T> constexpr bool operator!=(const T& v, const optional<T&>& x)
+        {
+            return bool(x) ? v != *x : true;
+        }
+
+        template <class T> constexpr bool operator<(const optional<T&>& x, const T& v)
+        {
+            return bool(x) ? *x < v : true;
+        }
+
+        template <class T> constexpr bool operator>(const T& v, const optional<T&>& x)
+        {
+            return bool(x) ? v > *x : true;
+        }
+
+        template <class T> constexpr bool operator>(const optional<T&>& x, const T& v)
+        {
+            return bool(x) ? *x > v : false;
+        }
+
+        template <class T> constexpr bool operator<(const T& v, const optional<T&>& x)
+        {
+            return bool(x) ? v < *x : false;
+        }
+
+        template <class T> constexpr bool operator>=(const optional<T&>& x, const T& v)
+        {
+            return bool(x) ? *x >= v : false;
+        }
+
+        template <class T> constexpr bool operator<=(const T& v, const optional<T&>& x)
+        {
+            return bool(x) ? v <= *x : false;
+        }
+
+        template <class T> constexpr bool operator<=(const optional<T&>& x, const T& v)
+        {
+            return bool(x) ? *x <= v : true;
+        }
+
+        template <class T> constexpr bool operator>=(const T& v, const optional<T&>& x)
+        {
+            return bool(x) ? v >= *x : true;
+        }
+
+        // Comparison of optional<T const&> with T
+        template <class T> constexpr bool operator==(const optional<const T&>& x, const T& v)
+        {
+            return bool(x) ? *x == v : false;
+        }
+
+        template <class T> constexpr bool operator==(const T& v, const optional<const T&>& x)
+        {
+            return bool(x) ? v == *x : false;
+        }
+
+        template <class T> constexpr bool operator!=(const optional<const T&>& x, const T& v)
+        {
+            return bool(x) ? *x != v : true;
+        }
+
+        template <class T> constexpr bool operator!=(const T& v, const optional<const T&>& x)
+        {
+            return bool(x) ? v != *x : true;
+        }
+
+        template <class T> constexpr bool operator<(const optional<const T&>& x, const T& v)
+        {
+            return bool(x) ? *x < v : true;
+        }
+
+        template <class T> constexpr bool operator>(const T& v, const optional<const T&>& x)
+        {
+            return bool(x) ? v > *x : true;
+        }
+
+        template <class T> constexpr bool operator>(const optional<const T&>& x, const T& v)
+        {
+            return bool(x) ? *x > v : false;
+        }
+
+        template <class T> constexpr bool operator<(const T& v, const optional<const T&>& x)
+        {
+            return bool(x) ? v < *x : false;
+        }
+
+        template <class T> constexpr bool operator>=(const optional<const T&>& x, const T& v)
+        {
+            return bool(x) ? *x >= v : false;
+        }
+
+        template <class T> constexpr bool operator<=(const T& v, const optional<const T&>& x)
+        {
+            return bool(x) ? v <= *x : false;
+        }
+
+        template <class T> constexpr bool operator<=(const optional<const T&>& x, const T& v)
+        {
+            return bool(x) ? *x <= v : true;
+        }
+
+        template <class T> constexpr bool operator>=(const T& v, const optional<const T&>& x)
+        {
+            return bool(x) ? v >= *x : true;
+        }
+
+
+        // 20.5.12, Specialized algorithms
+        template <class T>
+        void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y)))
+        {
+            x.swap(y);
+        }
+        
+        
+        template <class T>
+        constexpr optional<typename decay<T>::type> make_optional(T&& v)
+        {
+            return optional<typename decay<T>::type>(constexpr_forward<T>(v));
+        }
+        
+        template <class X>
+        constexpr optional<X&> make_optional(reference_wrapper<X> v)
+        {
+            return optional<X&>(v.get());
+        }
+        
+        
+    } // namespace experimental
 } // namespace std
 
 namespace std
 {
-	template <typename T>
-	struct hash<std::experimental::optional<T>>
-	{
-		typedef typename hash<T>::result_type result_type;
-		typedef std::experimental::optional<T> argument_type;
-		
-		constexpr result_type operator()(argument_type const& arg) const {
-			return arg ? std::hash<T>{}(*arg) : result_type{};
-		}
-	};
-	
-	template <typename T>
-	struct hash<std::experimental::optional<T&>>
-	{
-		typedef typename hash<T>::result_type result_type;
-		typedef std::experimental::optional<T&> argument_type;
-		
-		constexpr result_type operator()(argument_type const& arg) const {
-			return arg ? std::hash<T>{}(*arg) : result_type{};
-		}
-	};
+    template <typename T>
+    struct hash<std::experimental::optional<T>>
+    {
+        typedef typename hash<T>::result_type result_type;
+        typedef std::experimental::optional<T> argument_type;
+        
+        constexpr result_type operator()(argument_type const& arg) const {
+            return arg ? std::hash<T>{}(*arg) : result_type{};
+        }
+    };
+    
+    template <typename T>
+    struct hash<std::experimental::optional<T&>>
+    {
+        typedef typename hash<T>::result_type result_type;
+        typedef std::experimental::optional<T&> argument_type;
+        
+        constexpr result_type operator()(argument_type const& arg) const {
+            return arg ? std::hash<T>{}(*arg) : result_type{};
+        }
+    };
 }
 
 # undef TR2_OPTIONAL_REQUIRES

--- a/include/valijson/adapters/adapter.hpp
+++ b/include/valijson/adapters/adapter.hpp
@@ -2,7 +2,7 @@
 #ifndef __VALIJSON_ADAPTERS_ADAPTER_HPP
 #define __VALIJSON_ADAPTERS_ADAPTER_HPP
 
-#include <boost/function.hpp>
+#include <functional>
 
 namespace valijson {
 namespace adapters {
@@ -26,11 +26,11 @@ class Adapter
 public:
 
     /// Typedef for callback function supplied to applyToArray.
-    typedef boost::function<bool (const Adapter &)>
+    typedef std::function<bool (const Adapter &)>
         ArrayValueCallback;
 
     /// Typedef for callback function supplied to applyToObject.
-    typedef boost::function<bool (const std::string &, const Adapter &)>
+    typedef std::function<bool (const std::string &, const Adapter &)>
         ObjectMemberCallback;
 
     /**

--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -467,17 +467,13 @@ public:
         } else if (value.isInteger()) {
             int64_t integerValue;
             if (value.getInteger(integerValue)) {
-				std::stringstream ss;
-				ss << integerValue;
-				result = ss.str();
+				result = std::to_string(integerValue);
 				return true;
             }
         } else if (value.isDouble()) {
             double doubleValue;
             if (value.getDouble(doubleValue)) {
-				std::stringstream ss;
-				ss << doubleValue;
-				result = ss.str();
+				result = std::to_string(doubleValue);
 				return true;
             }
         }

--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -5,12 +5,12 @@
 #include <stdint.h>
 #include <sstream>
 
+// This should be removed once C++17 is widely available
 #if __has_include(<optional>)
 #  include <optional>
 namespace opt = std;
 #else
 #  include <compat/optional.hpp>
-#  define HAVE_EXPERIMENTAL_OPTIONAL 1
 namespace opt = std::experimental;
 #endif
 

--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -5,8 +5,12 @@
 #include <stdint.h>
 #include <sstream>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
+#if __has_include(<optional>)
+#  include <optional>
+#else
+#  include <compat/optional.hpp>
+#  define HAVE_EXPERIMENTAL_OPTIONAL 1
+#endif
 
 #include <valijson/adapters/adapter.hpp>
 
@@ -214,7 +218,7 @@ public:
         // effort of constructing an ArrayType instance if the value is
         // definitely an array.
         if (value.isArray()) {
-            const boost::optional<Array> array = value.getArrayOptional();
+			const std::experimental::optional<Array> array = value.getArrayOptional();
 			for( const AdapterType element : *array ) {
                 if (!fn(element)) {
                     return false;
@@ -232,7 +236,7 @@ public:
         }
 
         if (value.isObject()) {
-            const boost::optional<Object> object = value.getObjectOptional();
+			const std::experimental::optional<Object> object = value.getObjectOptional();
 			for( const ObjectMemberType member : *object ) {
                 if (!fn(member.first, AdapterType(member.second))) {
                     return false;
@@ -443,18 +447,18 @@ public:
         } else if (value.isInteger()) {
             int64_t integerValue;
             if (value.getInteger(integerValue)) {
-                try {
-                    result = boost::lexical_cast<std::string>(integerValue);
-                    return true;
-                } catch (boost::bad_lexical_cast &) { }
+				std::stringstream ss;
+				ss << integerValue;
+				result = ss.str();
+				return true;
             }
         } else if (value.isDouble()) {
             double doubleValue;
             if (value.getDouble(doubleValue)) {
-                try {
-                    result = boost::lexical_cast<std::string>(doubleValue);
-                    return true;
-                } catch (boost::bad_lexical_cast &) { }
+				std::stringstream ss;
+				ss << doubleValue;
+				result = ss.str();
+				return true;
             }
         }
 
@@ -481,7 +485,7 @@ public:
                 other.asString() == asString();
         } else if (isArray()) {
             if (other.isArray() && getArraySize() == other.getArraySize()) {
-                const boost::optional<ArrayType> array = value.getArrayOptional();
+                const std::experimental::optional<ArrayType> array = value.getArrayOptional();
                 if (array) {
                     ArrayComparisonFunctor fn(*array, strict);
                     return other.applyToArray(fn);
@@ -491,7 +495,7 @@ public:
             }
         } else if (isObject()) {
             if (other.isObject() && other.getObjectSize() == getObjectSize()) {
-                const boost::optional<ObjectType> object = value.getObjectOptional();
+                const std::experimental::optional<ObjectType> object = value.getObjectOptional();
                 if (object) {
                     ObjectComparisonFunctor fn(*object, strict);
                     return other.applyToObject(fn);
@@ -520,7 +524,7 @@ public:
      */
     ArrayType getArray() const
     {
-        boost::optional<ArrayType> arrayValue = value.getArrayOptional();
+        std::experimental::optional<ArrayType> arrayValue = value.getArrayOptional();
         if (arrayValue) {
             return *arrayValue;
         }
@@ -629,7 +633,7 @@ public:
      */
     ObjectType getObject() const
     {
-        boost::optional<ObjectType> objectValue = value.getObjectOptional();
+        std::experimental::optional<ObjectType> objectValue = value.getObjectOptional();
         if (objectValue) {
             return *objectValue;
         }

--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <sstream>
 
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/optional.hpp>
 
@@ -216,7 +215,7 @@ public:
         // definitely an array.
         if (value.isArray()) {
             const boost::optional<Array> array = value.getArrayOptional();
-            BOOST_FOREACH( const AdapterType element, *array ) {
+			for( const AdapterType element : *array ) {
                 if (!fn(element)) {
                     return false;
                 }
@@ -234,7 +233,7 @@ public:
 
         if (value.isObject()) {
             const boost::optional<Object> object = value.getObjectOptional();
-            BOOST_FOREACH( const ObjectMemberType member, *object ) {
+			for( const ObjectMemberType member : *object ) {
                 if (!fn(member.first, AdapterType(member.second))) {
                     return false;
                 }

--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -7,9 +7,11 @@
 
 #if __has_include(<optional>)
 #  include <optional>
+namespace opt = std;
 #else
 #  include <compat/optional.hpp>
 #  define HAVE_EXPERIMENTAL_OPTIONAL 1
+namespace opt = std::experimental;
 #endif
 
 #include <valijson/adapters/adapter.hpp>
@@ -218,7 +220,7 @@ public:
         // effort of constructing an ArrayType instance if the value is
         // definitely an array.
         if (value.isArray()) {
-			const std::experimental::optional<Array> array = value.getArrayOptional();
+			const opt::optional<Array> array = value.getArrayOptional();
 			for( const AdapterType element : *array ) {
                 if (!fn(element)) {
                     return false;
@@ -236,7 +238,7 @@ public:
         }
 
         if (value.isObject()) {
-			const std::experimental::optional<Object> object = value.getObjectOptional();
+			const opt::optional<Object> object = value.getObjectOptional();
 			for( const ObjectMemberType member : *object ) {
                 if (!fn(member.first, AdapterType(member.second))) {
                     return false;
@@ -485,7 +487,7 @@ public:
                 other.asString() == asString();
         } else if (isArray()) {
             if (other.isArray() && getArraySize() == other.getArraySize()) {
-                const std::experimental::optional<ArrayType> array = value.getArrayOptional();
+                const opt::optional<ArrayType> array = value.getArrayOptional();
                 if (array) {
                     ArrayComparisonFunctor fn(*array, strict);
                     return other.applyToArray(fn);
@@ -495,7 +497,7 @@ public:
             }
         } else if (isObject()) {
             if (other.isObject() && other.getObjectSize() == getObjectSize()) {
-                const std::experimental::optional<ObjectType> object = value.getObjectOptional();
+                const opt::optional<ObjectType> object = value.getObjectOptional();
                 if (object) {
                     ObjectComparisonFunctor fn(*object, strict);
                     return other.applyToObject(fn);
@@ -524,7 +526,7 @@ public:
      */
     ArrayType getArray() const
     {
-        std::experimental::optional<ArrayType> arrayValue = value.getArrayOptional();
+        opt::optional<ArrayType> arrayValue = value.getArrayOptional();
         if (arrayValue) {
             return *arrayValue;
         }
@@ -633,7 +635,7 @@ public:
      */
     ObjectType getObject() const
     {
-        std::experimental::optional<ObjectType> objectValue = value.getObjectOptional();
+        opt::optional<ObjectType> objectValue = value.getObjectOptional();
         if (objectValue) {
             return *objectValue;
         }

--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -30,11 +30,11 @@ namespace adapters {
 template<class Value>
 struct DerefProxy
 {
-	explicit DerefProxy(const Value& x) : m_ref(x) {}
-	Value* operator->() { return std::addressof(m_ref); }
-	operator Value*() { return std::addressof(m_ref); }
+    explicit DerefProxy(const Value& x) : m_ref(x) {}
+    Value* operator->() { return std::addressof(m_ref); }
+    operator Value*() { return std::addressof(m_ref); }
 
-	Value m_ref;
+    Value m_ref;
 };
 
 /**
@@ -238,8 +238,8 @@ public:
         // effort of constructing an ArrayType instance if the value is
         // definitely an array.
         if (value.isArray()) {
-			const opt::optional<Array> array = value.getArrayOptional();
-			for( const AdapterType element : *array ) {
+            const opt::optional<Array> array = value.getArrayOptional();
+            for( const AdapterType element : *array ) {
                 if (!fn(element)) {
                     return false;
                 }
@@ -256,8 +256,8 @@ public:
         }
 
         if (value.isObject()) {
-			const opt::optional<Object> object = value.getObjectOptional();
-			for( const ObjectMemberType member : *object ) {
+            const opt::optional<Object> object = value.getObjectOptional();
+            for( const ObjectMemberType member : *object ) {
                 if (!fn(member.first, AdapterType(member.second))) {
                     return false;
                 }
@@ -467,14 +467,14 @@ public:
         } else if (value.isInteger()) {
             int64_t integerValue;
             if (value.getInteger(integerValue)) {
-				result = std::to_string(integerValue);
-				return true;
+                result = std::to_string(integerValue);
+                return true;
             }
         } else if (value.isDouble()) {
             double doubleValue;
             if (value.getDouble(doubleValue)) {
-				result = std::to_string(doubleValue);
-				return true;
+                result = std::to_string(doubleValue);
+                return true;
             }
         }
 

--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -20,6 +20,24 @@ namespace valijson {
 namespace adapters {
 
 /**
+ * @brief  A helper for the array and object member iterators.
+ *
+ * See http://www.stlsoft.org/doc-1.9/group__group____pattern____dereference__proxy.html
+ * for motivation
+ *
+ * @tparam Value       Name of the value type
+ */
+template<class Value>
+struct DerefProxy
+{
+	explicit DerefProxy(const Value& x) : m_ref(x) {}
+	Value* operator->() { return std::addressof(m_ref); }
+	operator Value*() { return std::addressof(m_ref); }
+
+	Value m_ref;
+};
+
+/**
  * @brief  Template class that implements the expected semantics of an Adapter.
  *
  * Implementing all of the type-casting functionality for each Adapter is error

--- a/include/valijson/adapters/json11_adapter.hpp
+++ b/include/valijson/adapters/json11_adapter.hpp
@@ -292,13 +292,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<Json11Array> getArrayOptional() const
+    opt::optional<Json11Array> getArrayOptional() const
     {
         if (value.is_array()) {
-			return opt::make_optional(Json11Array(value));
+            return opt::make_optional(Json11Array(value));
         }
 
-		return opt::optional<Json11Array>();
+        return opt::optional<Json11Array>();
     }
 
     /**
@@ -360,13 +360,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<Json11Object> getObjectOptional() const
+    opt::optional<Json11Object> getObjectOptional() const
     {
         if (value.is_object()) {
-			return opt::make_optional(Json11Object(value));
+            return opt::make_optional(Json11Object(value));
         }
 
-		return opt::optional<Json11Object>();
+        return opt::optional<Json11Object>();
     }
 
     /**
@@ -497,7 +497,7 @@ public:
  */
 class Json11ArrayValueIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,  // bi-directional iterator
+        std::bidirectional_iterator_tag,  // bi-directional iterator
         Json11Adapter>                    // value type
 {
 public:
@@ -519,10 +519,10 @@ public:
         return Json11Adapter(*itr);
     }
 
-	DerefProxy<Json11Adapter> operator->() const
-	{
-		return DerefProxy<Json11Adapter>(**this);
-	}
+    DerefProxy<Json11Adapter> operator->() const
+    {
+        return DerefProxy<Json11Adapter>(**this);
+    }
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -540,31 +540,31 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const Json11ArrayValueIterator &other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const Json11ArrayValueIterator &other) const
+    {
+        return !(itr == other.itr);
+    }
 
     const Json11ArrayValueIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	Json11ArrayValueIterator operator++(int)
-	{
-		Json11ArrayValueIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    Json11ArrayValueIterator operator++(int)
+    {
+        Json11ArrayValueIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const Json11ArrayValueIterator& operator--()
+    const Json11ArrayValueIterator& operator--()
     {
         itr--;
 
-		return *this;
-	}
+        return *this;
+    }
 
     void advance(std::ptrdiff_t n)
     {
@@ -588,7 +588,7 @@ private:
  */
 class Json11ObjectMemberIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,   // bi-directional iterator
+        std::bidirectional_iterator_tag,   // bi-directional iterator
         Json11ObjectMember>                // value type
 {
 public:
@@ -611,10 +611,10 @@ public:
         return Json11ObjectMember(itr->first, itr->second);
     }
 
-	DerefProxy<Json11ObjectMember> operator->() const
-	{
-		return DerefProxy<Json11ObjectMember>(**this);
-	}
+    DerefProxy<Json11ObjectMember> operator->() const
+    {
+        return DerefProxy<Json11ObjectMember>(**this);
+    }
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -632,31 +632,31 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const Json11ObjectMemberIterator &other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const Json11ObjectMemberIterator &other) const
+    {
+        return !(itr == other.itr);
+    }
 
     const Json11ObjectMemberIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	Json11ObjectMemberIterator operator++(int)
-	{
-		Json11ObjectMemberIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    Json11ObjectMemberIterator operator++(int)
+    {
+        Json11ObjectMemberIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const Json11ObjectMemberIterator& operator--()
-	{
-		itr--;
+    const Json11ObjectMemberIterator& operator--()
+    {
+        itr--;
 
-		return *this;
-	}
+        return *this;
+    }
 
 private:
 

--- a/include/valijson/adapters/json11_adapter.hpp
+++ b/include/valijson/adapters/json11_adapter.hpp
@@ -496,11 +496,9 @@ public:
  * @see Json11Array
  */
 class Json11ArrayValueIterator:
-    public boost::iterator_facade<
-        Json11ArrayValueIterator,          // name of derived type
-        Json11Adapter,                     // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        Json11Adapter>                     // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,  // bi-directional iterator
+        Json11Adapter>                    // value type
 {
 public:
 
@@ -516,10 +514,15 @@ public:
 
     /// Returns a Json11Adapter that contains the value of the current
     /// element.
-    Json11Adapter dereference() const
+    Json11Adapter operator*() const
     {
         return Json11Adapter(*itr);
     }
+
+	DerefProxy<Json11Adapter> operator->() const
+	{
+		return DerefProxy<Json11Adapter>(**this);
+	}
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -532,20 +535,36 @@ public:
      *
      * @returns true   if the iterators are equal, false otherwise.
      */
-    bool equal(const Json11ArrayValueIterator &other) const
+    bool operator==(const Json11ArrayValueIterator &other) const
     {
         return itr == other.itr;
     }
 
-    void increment()
+	bool operator!=(const Json11ArrayValueIterator &other) const
+	{
+		return !(itr == other.itr);
+	}
+
+    const Json11ArrayValueIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
+	Json11ArrayValueIterator operator++(int)
+	{
+		Json11ArrayValueIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const Json11ArrayValueIterator& operator--()
     {
         itr--;
-    }
+
+		return *this;
+	}
 
     void advance(std::ptrdiff_t n)
     {
@@ -568,11 +587,9 @@ private:
  * @see Json11ObjectMember
  */
 class Json11ObjectMemberIterator:
-    public boost::iterator_facade<
-        Json11ObjectMemberIterator,        // name of derived type
-        Json11ObjectMember,                // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        Json11ObjectMember>                // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,   // bi-directional iterator
+        Json11ObjectMember>                // value type
 {
 public:
 
@@ -589,10 +606,15 @@ public:
      * @brief   Returns a Json11ObjectMember that contains the key and value
      *          belonging to the object member identified by the iterator.
      */
-    Json11ObjectMember dereference() const
+    Json11ObjectMember operator*() const
     {
         return Json11ObjectMember(itr->first, itr->second);
     }
+
+	DerefProxy<Json11ObjectMember> operator->() const
+	{
+		return DerefProxy<Json11ObjectMember>(**this);
+	}
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -605,20 +627,36 @@ public:
      *
      * @returns true if the underlying iterators are equal, false otherwise
      */
-    bool equal(const Json11ObjectMemberIterator &other) const
+    bool operator==(const Json11ObjectMemberIterator &other) const
     {
         return itr == other.itr;
     }
 
-    void increment()
+	bool operator!=(const Json11ObjectMemberIterator &other) const
+	{
+		return !(itr == other.itr);
+	}
+
+    const Json11ObjectMemberIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
-    {
-        itr--;
-    }
+	Json11ObjectMemberIterator operator++(int)
+	{
+		Json11ObjectMemberIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const Json11ObjectMemberIterator& operator--()
+	{
+		itr--;
+
+		return *this;
+	}
 
 private:
 

--- a/include/valijson/adapters/json11_adapter.hpp
+++ b/include/valijson/adapters/json11_adapter.hpp
@@ -293,13 +293,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<Json11Array> getArrayOptional() const
+	opt::optional<Json11Array> getArrayOptional() const
     {
         if (value.is_array()) {
-			return std::experimental::make_optional(Json11Array(value));
+			return opt::make_optional(Json11Array(value));
         }
 
-		return std::experimental::optional<Json11Array>();
+		return opt::optional<Json11Array>();
     }
 
     /**
@@ -361,13 +361,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<Json11Object> getObjectOptional() const
+	opt::optional<Json11Object> getObjectOptional() const
     {
         if (value.is_object()) {
-			return std::experimental::make_optional(Json11Object(value));
+			return opt::make_optional(Json11Object(value));
         }
 
-		return std::experimental::optional<Json11Object>();
+		return opt::optional<Json11Object>();
     }
 
     /**

--- a/include/valijson/adapters/json11_adapter.hpp
+++ b/include/valijson/adapters/json11_adapter.hpp
@@ -29,7 +29,6 @@
 
 #include <string>
 #include <json11.hpp>
-#include <boost/optional.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <valijson/adapters/adapter.hpp>
@@ -289,18 +288,18 @@ public:
      * @brief   Optionally return a Json11Array instance.
      *
      * If the referenced Json11 value is an array, this function will return
-     * a boost::optional containing a Json11Array instance referencing the
+     * a std::optional containing a Json11Array instance referencing the
      * array.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<Json11Array> getArrayOptional() const
+	std::experimental::optional<Json11Array> getArrayOptional() const
     {
         if (value.is_array()) {
-            return boost::make_optional(Json11Array(value));
+			return std::experimental::make_optional(Json11Array(value));
         }
 
-        return boost::none;
+		return std::experimental::optional<Json11Array>();
     }
 
     /**
@@ -357,18 +356,18 @@ public:
      * @brief   Optionally return a Json11Object instance.
      *
      * If the referenced Json11 value is an object, this function will return a
-     * boost::optional containing a Json11Object instance referencing the
+     * std::optional containing a Json11Object instance referencing the
      * object.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<Json11Object> getObjectOptional() const
+	std::experimental::optional<Json11Object> getObjectOptional() const
     {
         if (value.is_object()) {
-            return boost::make_optional(Json11Object(value));
+			return std::experimental::make_optional(Json11Object(value));
         }
 
-        return boost::none;
+		return std::experimental::optional<Json11Object>();
     }
 
     /**

--- a/include/valijson/adapters/json11_adapter.hpp
+++ b/include/valijson/adapters/json11_adapter.hpp
@@ -29,7 +29,6 @@
 
 #include <string>
 #include <json11.hpp>
-#include <boost/iterator/iterator_facade.hpp>
 
 #include <valijson/adapters/adapter.hpp>
 #include <valijson/adapters/basic_adapter.hpp>

--- a/include/valijson/adapters/jsoncpp_adapter.hpp
+++ b/include/valijson/adapters/jsoncpp_adapter.hpp
@@ -289,13 +289,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-    std::experimental::optional<JsonCppArray> getArrayOptional() const
+    opt::optional<JsonCppArray> getArrayOptional() const
     {
         if (value.isArray()) {
-			return std::experimental::make_optional(JsonCppArray(value));
+			return opt::make_optional(JsonCppArray(value));
         }
 
-		return std::experimental::optional<JsonCppArray>();
+		return opt::optional<JsonCppArray>();
     }
 
     /**
@@ -358,13 +358,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-    std::experimental::optional<JsonCppObject> getObjectOptional() const
+    opt::optional<JsonCppObject> getObjectOptional() const
     {
         if (value.isObject()) {
-            return std::experimental::make_optional(JsonCppObject(value));
+            return opt::make_optional(JsonCppObject(value));
         }
 
-		return std::experimental::optional<JsonCppObject>();
+		return opt::optional<JsonCppObject>();
     }
 
     /**

--- a/include/valijson/adapters/jsoncpp_adapter.hpp
+++ b/include/valijson/adapters/jsoncpp_adapter.hpp
@@ -284,18 +284,18 @@ public:
      * @brief   Optionally return a JsonCppArray instance.
      *
      * If the referenced JsonCpp value is an array, this function will return a
-     * boost::optional containing a JsonCppArray instance referencing the
+     * std::optional containing a JsonCppArray instance referencing the
      * array.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<JsonCppArray> getArrayOptional() const
+    std::experimental::optional<JsonCppArray> getArrayOptional() const
     {
         if (value.isArray()) {
-            return boost::make_optional(JsonCppArray(value));
+			return std::experimental::make_optional(JsonCppArray(value));
         }
 
-        return boost::none;
+		return std::experimental::optional<JsonCppArray>();
     }
 
     /**
@@ -353,18 +353,18 @@ public:
      * @brief   Optionally return a JsonCppObject instance.
      *
      * If the referenced JsonCpp value is an object, this function will return a
-     * boost::optional containing a JsonCppObject instance referencing the
+     * std::optional containing a JsonCppObject instance referencing the
      * object.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<JsonCppObject> getObjectOptional() const
+    std::experimental::optional<JsonCppObject> getObjectOptional() const
     {
         if (value.isObject()) {
-            return boost::make_optional(JsonCppObject(value));
+            return std::experimental::make_optional(JsonCppObject(value));
         }
 
-        return boost::none;
+		return std::experimental::optional<JsonCppObject>();
     }
 
     /**

--- a/include/valijson/adapters/jsoncpp_adapter.hpp
+++ b/include/valijson/adapters/jsoncpp_adapter.hpp
@@ -291,10 +291,10 @@ public:
     opt::optional<JsonCppArray> getArrayOptional() const
     {
         if (value.isArray()) {
-			return opt::make_optional(JsonCppArray(value));
+            return opt::make_optional(JsonCppArray(value));
         }
 
-		return opt::optional<JsonCppArray>();
+        return opt::optional<JsonCppArray>();
     }
 
     /**
@@ -363,7 +363,7 @@ public:
             return opt::make_optional(JsonCppObject(value));
         }
 
-		return opt::optional<JsonCppObject>();
+        return opt::optional<JsonCppObject>();
     }
 
     /**
@@ -493,7 +493,7 @@ public:
  */
 class JsonCppArrayValueIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        std::bidirectional_iterator_tag,     // bi-directional iterator
         JsonCppAdapter>                      // value type
 {
 
@@ -514,10 +514,10 @@ public:
         return JsonCppAdapter(*itr);
     }
 
-	DerefProxy<JsonCppAdapter> operator->() const
-	{
-		return DerefProxy<JsonCppAdapter>(**this);
-	}
+    DerefProxy<JsonCppAdapter> operator->() const
+    {
+        return DerefProxy<JsonCppAdapter>(**this);
+    }
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -535,31 +535,31 @@ public:
         return itr == rhs.itr;
     }
 
-	bool operator!=(const JsonCppArrayValueIterator &rhs) const
-	{
-		return !(itr == rhs.itr);
-	}
+    bool operator!=(const JsonCppArrayValueIterator &rhs) const
+    {
+        return !(itr == rhs.itr);
+    }
 
-	JsonCppArrayValueIterator& operator++()
-	{
-		itr++;
+    JsonCppArrayValueIterator& operator++()
+    {
+        itr++;
 
-		return *this;
-	}
+        return *this;
+    }
 
-	JsonCppArrayValueIterator operator++(int)
-	{
-		JsonCppArrayValueIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    JsonCppArrayValueIterator operator++(int)
+    {
+        JsonCppArrayValueIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	JsonCppArrayValueIterator& operator--()
-	{
-		itr--;
+    JsonCppArrayValueIterator& operator--()
+    {
+        itr--;
 
-		return *this;
-	}
+        return *this;
+    }
 
     void advance(std::ptrdiff_t n)
     {
@@ -591,7 +591,7 @@ private:
  */
 class JsonCppObjectMemberIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        std::bidirectional_iterator_tag,     // bi-directional iterator
         JsonCppObjectMember>                 // value type
 {
 public:
@@ -613,10 +613,10 @@ public:
         return JsonCppObjectMember(itr.key().asString(), *itr);
     }
 
-	DerefProxy<JsonCppObjectMember> operator->() const
-	{
-		return DerefProxy<JsonCppObjectMember>(**this);
-	}
+    DerefProxy<JsonCppObjectMember> operator->() const
+    {
+        return DerefProxy<JsonCppObjectMember>(**this);
+    }
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -634,30 +634,30 @@ public:
         return itr == rhs.itr;
     }
 
-	bool operator!=(const JsonCppObjectMemberIterator &rhs) const
-	{
-		return !(itr == rhs.itr);
-	}
+    bool operator!=(const JsonCppObjectMemberIterator &rhs) const
+    {
+        return !(itr == rhs.itr);
+    }
 
     const JsonCppObjectMemberIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	JsonCppObjectMemberIterator operator++(int)
-	{
-		JsonCppObjectMemberIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    JsonCppObjectMemberIterator operator++(int)
+    {
+        JsonCppObjectMemberIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	JsonCppObjectMemberIterator operator--()
+    JsonCppObjectMemberIterator operator--()
     {
         itr--;
 
-		return *this;
+        return *this;
     }
 
 private:

--- a/include/valijson/adapters/jsoncpp_adapter.hpp
+++ b/include/valijson/adapters/jsoncpp_adapter.hpp
@@ -29,8 +29,7 @@
 
 #include <stdint.h>
 #include <string>
-#include <boost/bind.hpp>
-#include <boost/iterator/iterator_facade.hpp>
+#include <iterator>
 
 #include <json/json.h>
 
@@ -493,12 +492,21 @@ public:
  * @see JsonCppArray
  */
 class JsonCppArrayValueIterator:
-    public boost::iterator_facade<
-        JsonCppArrayValueIterator,           // name of derived type
-        JsonCppAdapter,                      // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        JsonCppAdapter>                      // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        JsonCppAdapter>                      // value type
 {
+private:
+
+	struct proxy
+	{
+		explicit proxy(const JsonCppAdapter& x) : m_ref(x) {}
+		JsonCppAdapter* operator->() { return std::addressof(m_ref); }
+		operator JsonCppAdapter*() { return std::addressof(m_ref); }
+
+		JsonCppAdapter m_ref;
+	};
+
 public:
 
     /**
@@ -511,10 +519,15 @@ public:
       : itr(itr) { }
 
     /// Returns a JsonCppAdapter that contains the value of the current element.
-    JsonCppAdapter dereference() const
+    JsonCppAdapter operator*() const
     {
         return JsonCppAdapter(*itr);
     }
+
+	proxy operator->() const
+	{
+		return proxy(**this);
+	}
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -527,20 +540,36 @@ public:
      *
      * @returns true if the iterators are equal, false otherwise.
      */
-    bool equal(const JsonCppArrayValueIterator &rhs) const
+    bool operator==(const JsonCppArrayValueIterator &rhs) const
     {
         return itr == rhs.itr;
     }
 
-    void increment()
-    {
-        itr++;
-    }
+	bool operator!=(const JsonCppArrayValueIterator &rhs) const
+	{
+		return !(itr == rhs.itr);
+	}
 
-    void decrement()
-    {
-        itr--;
-    }
+	JsonCppArrayValueIterator& operator++()
+	{
+		itr++;
+
+		return *this;
+	}
+
+	JsonCppArrayValueIterator operator++(int)
+	{
+		JsonCppArrayValueIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	JsonCppArrayValueIterator& operator--()
+	{
+		itr--;
+
+		return *this;
+	}
 
     void advance(std::ptrdiff_t n)
     {
@@ -571,12 +600,21 @@ private:
  * @see JsonCppObjectMember
  */
 class JsonCppObjectMemberIterator:
-    public boost::iterator_facade<
-        JsonCppObjectMemberIterator,         // name of derived type
-        JsonCppObjectMember,                 // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        JsonCppObjectMember>                 // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        JsonCppObjectMember>                 // value type
 {
+private:
+
+	struct proxy
+	{
+		explicit proxy(const JsonCppObjectMember& x) : m_ref(x) {}
+		JsonCppObjectMember* operator->() { return std::addressof(m_ref); }
+		operator JsonCppObjectMember*() { return std::addressof(m_ref); }
+
+		JsonCppObjectMember m_ref;
+	};
+
 public:
 
     /**
@@ -591,10 +629,15 @@ public:
      * @brief   Returns a JsonCppObjectMember that contains the key and value
      *          belonging to the object member identified by the iterator.
      */
-    JsonCppObjectMember dereference() const
+    JsonCppObjectMember operator*() const
     {
         return JsonCppObjectMember(itr.key().asString(), *itr);
     }
+
+	proxy operator->() const
+	{
+		return proxy(**this);
+	}
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -607,19 +650,35 @@ public:
      *
      * @returns true if the underlying iterators are equal, false otherwise
      */
-    bool equal(const JsonCppObjectMemberIterator &rhs) const
+    bool operator==(const JsonCppObjectMemberIterator &rhs) const
     {
         return itr == rhs.itr;
     }
 
-    void increment()
+	bool operator!=(const JsonCppObjectMemberIterator &rhs) const
+	{
+		return !(itr == rhs.itr);
+	}
+
+    const JsonCppObjectMemberIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
+	JsonCppObjectMemberIterator operator++(int)
+	{
+		JsonCppObjectMemberIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	JsonCppObjectMemberIterator operator--()
     {
         itr--;
+
+		return *this;
     }
 
 private:

--- a/include/valijson/adapters/jsoncpp_adapter.hpp
+++ b/include/valijson/adapters/jsoncpp_adapter.hpp
@@ -496,16 +496,6 @@ class JsonCppArrayValueIterator:
 	    std::bidirectional_iterator_tag,     // bi-directional iterator
         JsonCppAdapter>                      // value type
 {
-private:
-
-	struct proxy
-	{
-		explicit proxy(const JsonCppAdapter& x) : m_ref(x) {}
-		JsonCppAdapter* operator->() { return std::addressof(m_ref); }
-		operator JsonCppAdapter*() { return std::addressof(m_ref); }
-
-		JsonCppAdapter m_ref;
-	};
 
 public:
 
@@ -524,9 +514,9 @@ public:
         return JsonCppAdapter(*itr);
     }
 
-	proxy operator->() const
+	DerefProxy<JsonCppAdapter> operator->() const
 	{
-		return proxy(**this);
+		return DerefProxy<JsonCppAdapter>(**this);
 	}
 
     /**
@@ -604,17 +594,6 @@ class JsonCppObjectMemberIterator:
 	    std::bidirectional_iterator_tag,     // bi-directional iterator
         JsonCppObjectMember>                 // value type
 {
-private:
-
-	struct proxy
-	{
-		explicit proxy(const JsonCppObjectMember& x) : m_ref(x) {}
-		JsonCppObjectMember* operator->() { return std::addressof(m_ref); }
-		operator JsonCppObjectMember*() { return std::addressof(m_ref); }
-
-		JsonCppObjectMember m_ref;
-	};
-
 public:
 
     /**
@@ -634,9 +613,9 @@ public:
         return JsonCppObjectMember(itr.key().asString(), *itr);
     }
 
-	proxy operator->() const
+	DerefProxy<JsonCppObjectMember> operator->() const
 	{
-		return proxy(**this);
+		return DerefProxy<JsonCppObjectMember>(**this);
 	}
 
     /**

--- a/include/valijson/adapters/nlohmann_json_adapter.hpp
+++ b/include/valijson/adapters/nlohmann_json_adapter.hpp
@@ -294,14 +294,14 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<NlohmannJsonArray> getArrayOptional() const
+    opt::optional<NlohmannJsonArray> getArrayOptional() const
     {
         if (value.is_array()) {
-			return opt::make_optional(NlohmannJsonArray(value));
+            return opt::make_optional(NlohmannJsonArray(value));
         }
 
-		return opt::optional<NlohmannJsonArray>();
-	}
+        return opt::optional<NlohmannJsonArray>();
+    }
 
     /**
      * @brief   Retrieve the number of elements in the array
@@ -362,10 +362,10 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<NlohmannJsonObject> getObjectOptional() const
+    opt::optional<NlohmannJsonObject> getObjectOptional() const
     {
         if (value.is_object()) {
-			return opt::make_optional(NlohmannJsonObject(value));
+            return opt::make_optional(NlohmannJsonObject(value));
         }
 
         return opt::optional<NlohmannJsonObject>();
@@ -497,7 +497,7 @@ public:
  */
 class NlohmannJsonArrayValueIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,  // bi-directional iterator
+        std::bidirectional_iterator_tag,  // bi-directional iterator
         NlohmannJsonAdapter>                 // value type
 {
 public:
@@ -518,10 +518,10 @@ public:
         return NlohmannJsonAdapter(*itr);
     }
 
-	DerefProxy<NlohmannJsonAdapter> operator->() const
-	{
-		return DerefProxy<NlohmannJsonAdapter>(**this);
-	}
+    DerefProxy<NlohmannJsonAdapter> operator->() const
+    {
+        return DerefProxy<NlohmannJsonAdapter>(**this);
+    }
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -539,31 +539,31 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const NlohmannJsonArrayValueIterator &other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const NlohmannJsonArrayValueIterator &other) const
+    {
+        return !(itr == other.itr);
+    }
 
     const NlohmannJsonArrayValueIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	NlohmannJsonArrayValueIterator operator++(int)
-	{
-		NlohmannJsonArrayValueIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    NlohmannJsonArrayValueIterator operator++(int)
+    {
+        NlohmannJsonArrayValueIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const NlohmannJsonArrayValueIterator& operator--()
-	{
-		itr--;
+    const NlohmannJsonArrayValueIterator& operator--()
+    {
+        itr--;
 
-		return *this;
-	}
+        return *this;
+    }
 
     void advance(std::ptrdiff_t n)
     {
@@ -587,7 +587,7 @@ private:
  */
 class NlohmannJsonObjectMemberIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        std::bidirectional_iterator_tag,     // bi-directional iterator
         NlohmannJsonObjectMember>            // value type
 {
 public:
@@ -609,10 +609,10 @@ public:
         return NlohmannJsonObjectMember(itr.key(), itr.value());
     }
 
-	DerefProxy<NlohmannJsonObjectMember> operator->() const
-	{
-		return DerefProxy<NlohmannJsonObjectMember>(**this);
-	}
+    DerefProxy<NlohmannJsonObjectMember> operator->() const
+    {
+        return DerefProxy<NlohmannJsonObjectMember>(**this);
+    }
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -630,31 +630,31 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const NlohmannJsonObjectMemberIterator &other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const NlohmannJsonObjectMemberIterator &other) const
+    {
+        return !(itr == other.itr);
+    }
 
     const NlohmannJsonObjectMemberIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	NlohmannJsonObjectMemberIterator operator++(int)
-	{
-		NlohmannJsonObjectMemberIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    NlohmannJsonObjectMemberIterator operator++(int)
+    {
+        NlohmannJsonObjectMemberIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const NlohmannJsonObjectMemberIterator& operator--()
-	{
-		itr--;
+    const NlohmannJsonObjectMemberIterator& operator--()
+    {
+        itr--;
 
-		return *this;
-	}
+        return *this;
+    }
 
 private:
 

--- a/include/valijson/adapters/nlohmann_json_adapter.hpp
+++ b/include/valijson/adapters/nlohmann_json_adapter.hpp
@@ -29,8 +29,6 @@
 
 #include <string>
 #include <json.hpp>
-#include <boost/optional.hpp>
-#include <boost/iterator/iterator_facade.hpp>
 
 #include <valijson/adapters/adapter.hpp>
 #include <valijson/adapters/basic_adapter.hpp>

--- a/include/valijson/adapters/nlohmann_json_adapter.hpp
+++ b/include/valijson/adapters/nlohmann_json_adapter.hpp
@@ -496,11 +496,9 @@ public:
  * @see NlohmannJsonArray
  */
 class NlohmannJsonArrayValueIterator:
-    public boost::iterator_facade<
-        NlohmannJsonArrayValueIterator,      // name of derived type
-        NlohmannJsonAdapter,                 // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        NlohmannJsonAdapter>                 // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,  // bi-directional iterator
+        NlohmannJsonAdapter>                 // value type
 {
 public:
 
@@ -515,10 +513,15 @@ public:
 
     /// Returns a NlohmannJsonAdapter that contains the value of the current
     /// element.
-    NlohmannJsonAdapter dereference() const
+    NlohmannJsonAdapter operator*() const
     {
         return NlohmannJsonAdapter(*itr);
     }
+
+	DerefProxy<NlohmannJsonAdapter> operator->() const
+	{
+		return DerefProxy<NlohmannJsonAdapter>(**this);
+	}
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -531,20 +534,36 @@ public:
      *
      * @returns true   if the iterators are equal, false otherwise.
      */
-    bool equal(const NlohmannJsonArrayValueIterator &other) const
+    bool operator==(const NlohmannJsonArrayValueIterator &other) const
     {
         return itr == other.itr;
     }
 
-    void increment()
+	bool operator!=(const NlohmannJsonArrayValueIterator &other) const
+	{
+		return !(itr == other.itr);
+	}
+
+    const NlohmannJsonArrayValueIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
-    {
-        itr--;
-    }
+	NlohmannJsonArrayValueIterator operator++(int)
+	{
+		NlohmannJsonArrayValueIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const NlohmannJsonArrayValueIterator& operator--()
+	{
+		itr--;
+
+		return *this;
+	}
 
     void advance(std::ptrdiff_t n)
     {
@@ -567,11 +586,9 @@ private:
  * @see NlohmannJsonObjectMember
  */
 class NlohmannJsonObjectMemberIterator:
-    public boost::iterator_facade<
-        NlohmannJsonObjectMemberIterator,    // name of derived type
-        NlohmannJsonObjectMember,            // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        NlohmannJsonObjectMember>            // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        NlohmannJsonObjectMember>            // value type
 {
 public:
 
@@ -587,10 +604,15 @@ public:
      * @brief   Returns a NlohmannJsonObjectMember that contains the key and value
      *          belonging to the object member identified by the iterator.
      */
-    NlohmannJsonObjectMember dereference() const
+    NlohmannJsonObjectMember operator*() const
     {
         return NlohmannJsonObjectMember(itr.key(), itr.value());
     }
+
+	DerefProxy<NlohmannJsonObjectMember> operator->() const
+	{
+		return DerefProxy<NlohmannJsonObjectMember>(**this);
+	}
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -603,20 +625,36 @@ public:
      *
      * @returns true if the underlying iterators are equal, false otherwise
      */
-    bool equal(const NlohmannJsonObjectMemberIterator &other) const
+    bool operator==(const NlohmannJsonObjectMemberIterator &other) const
     {
         return itr == other.itr;
     }
 
-    void increment()
+	bool operator!=(const NlohmannJsonObjectMemberIterator &other) const
+	{
+		return !(itr == other.itr);
+	}
+
+    const NlohmannJsonObjectMemberIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
-    {
-        itr--;
-    }
+	NlohmannJsonObjectMemberIterator operator++(int)
+	{
+		NlohmannJsonObjectMemberIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const NlohmannJsonObjectMemberIterator& operator--()
+	{
+		itr--;
+
+		return *this;
+	}
 
 private:
 

--- a/include/valijson/adapters/nlohmann_json_adapter.hpp
+++ b/include/valijson/adapters/nlohmann_json_adapter.hpp
@@ -291,19 +291,19 @@ public:
      * @brief   Optionally return a NlohmannJsonArray instance.
      *
      * If the referenced NlohmannJson value is an array, this function will return
-     * a boost::optional containing a NlohmannJsonArray instance referencing the
+     * a std::optional containing a NlohmannJsonArray instance referencing the
      * array.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<NlohmannJsonArray> getArrayOptional() const
+	std::experimental::optional<NlohmannJsonArray> getArrayOptional() const
     {
         if (value.is_array()) {
-            return boost::make_optional(NlohmannJsonArray(value));
+			return std::experimental::make_optional(NlohmannJsonArray(value));
         }
 
-        return boost::none;
-    }
+		return std::experimental::optional<NlohmannJsonArray>();
+	}
 
     /**
      * @brief   Retrieve the number of elements in the array
@@ -359,18 +359,18 @@ public:
      * @brief   Optionally return a NlohmannJsonObject instance.
      *
      * If the referenced NlohmannJson value is an object, this function will return a
-     * boost::optional containing a NlohmannJsonObject instance referencing the
+     * std::optional containing a NlohmannJsonObject instance referencing the
      * object.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<NlohmannJsonObject> getObjectOptional() const
+	std::experimental::optional<NlohmannJsonObject> getObjectOptional() const
     {
         if (value.is_object()) {
-            return boost::make_optional(NlohmannJsonObject(value));
+			return std::experimental::make_optional(NlohmannJsonObject(value));
         }
 
-        return boost::none;
+        return std::experimental::optional<NlohmannJsonObject>();
     }
 
     /**

--- a/include/valijson/adapters/nlohmann_json_adapter.hpp
+++ b/include/valijson/adapters/nlohmann_json_adapter.hpp
@@ -296,13 +296,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<NlohmannJsonArray> getArrayOptional() const
+	opt::optional<NlohmannJsonArray> getArrayOptional() const
     {
         if (value.is_array()) {
-			return std::experimental::make_optional(NlohmannJsonArray(value));
+			return opt::make_optional(NlohmannJsonArray(value));
         }
 
-		return std::experimental::optional<NlohmannJsonArray>();
+		return opt::optional<NlohmannJsonArray>();
 	}
 
     /**
@@ -364,13 +364,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<NlohmannJsonObject> getObjectOptional() const
+	opt::optional<NlohmannJsonObject> getObjectOptional() const
     {
         if (value.is_object()) {
-			return std::experimental::make_optional(NlohmannJsonObject(value));
+			return opt::make_optional(NlohmannJsonObject(value));
         }
 
-        return std::experimental::optional<NlohmannJsonObject>();
+        return opt::optional<NlohmannJsonObject>();
     }
 
     /**

--- a/include/valijson/adapters/picojson_adapter.hpp
+++ b/include/valijson/adapters/picojson_adapter.hpp
@@ -28,9 +28,6 @@
 #define __VALIJSON_ADAPTERS_PICOJSON_ADAPTER_HPP
 
 #include <string>
-#include <boost/bind.hpp>
-#include <boost/optional.hpp>
-#include <boost/iterator/iterator_facade.hpp>
 
 #include <picojson.h>
 
@@ -508,12 +505,21 @@ public:
  * @see PicoJsonArray
  */
 class PicoJsonArrayValueIterator:
-    public boost::iterator_facade<
-        PicoJsonArrayValueIterator,          // name of derived type
-        PicoJsonAdapter,                     // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        PicoJsonAdapter>                     // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        PicoJsonAdapter>                     // value type
 {
+private:
+
+	struct proxy
+	{
+		explicit proxy(const PicoJsonAdapter& x) : m_ref(x) {}
+		PicoJsonAdapter* operator->() { return std::addressof(m_ref); }
+		operator PicoJsonAdapter*() { return std::addressof(m_ref); }
+
+		PicoJsonAdapter m_ref;
+	};
+
 public:
 
     /**
@@ -528,10 +534,15 @@ public:
 
     /// Returns a PicoJsonAdapter that contains the value of the current
     /// element.
-    PicoJsonAdapter dereference() const
+    PicoJsonAdapter operator*() const
     {
         return PicoJsonAdapter(*itr);
     }
+
+	proxy operator->() const
+	{
+		return proxy(**this);
+	}
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -544,20 +555,36 @@ public:
      *
      * @returns true   if the iterators are equal, false otherwise.
      */
-    bool equal(const PicoJsonArrayValueIterator &other) const
+    bool operator==(const PicoJsonArrayValueIterator &other) const
     {
         return itr == other.itr;
     }
 
-    void increment()
+	bool operator!=(const PicoJsonArrayValueIterator &other) const
+	{
+		return !(itr == other.itr);
+	}
+
+    const PicoJsonArrayValueIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
-    {
-        itr--;
-    }
+	PicoJsonArrayValueIterator operator++(int)
+	{
+		PicoJsonArrayValueIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const PicoJsonArrayValueIterator& operator--()
+	{
+		itr--;
+
+		return *this;
+	}
 
     void advance(std::ptrdiff_t n)
     {
@@ -580,12 +607,21 @@ private:
  * @see PicoJsonObjectMember
  */
 class PicoJsonObjectMemberIterator:
-    public boost::iterator_facade<
-        PicoJsonObjectMemberIterator,        // name of derived type
-        PicoJsonObjectMember,                // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        PicoJsonObjectMember>                // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,  // bi-directional iterator
+        PicoJsonObjectMember>             // value type
 {
+private:
+
+	struct proxy
+	{
+		explicit proxy(const PicoJsonObjectMember& x) : m_ref(x) {}
+		PicoJsonObjectMember* operator->() { return std::addressof(m_ref); }
+		operator PicoJsonObjectMember*() { return std::addressof(m_ref); }
+
+		PicoJsonObjectMember m_ref;
+	};
+
 public:
 
     /**
@@ -601,10 +637,15 @@ public:
      * @brief   Returns a PicoJsonObjectMember that contains the key and value
      *          belonging to the object member identified by the iterator.
      */
-    PicoJsonObjectMember dereference() const
+    PicoJsonObjectMember operator*() const
     {
         return PicoJsonObjectMember(itr->first, itr->second);
     }
+
+	proxy operator->() const
+	{
+		return proxy(**this);
+	}
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -617,19 +658,35 @@ public:
      *
      * @returns true if the underlying iterators are equal, false otherwise
      */
-    bool equal(const PicoJsonObjectMemberIterator &other) const
+    bool operator==(const PicoJsonObjectMemberIterator &other) const
     {
         return itr == other.itr;
     }
 
-    void increment()
+	bool operator!=(const PicoJsonObjectMemberIterator &other) const
+	{
+		return !(itr == other.itr);
+	}
+
+    const PicoJsonObjectMemberIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
+	PicoJsonObjectMemberIterator operator++(int)
+	{
+		PicoJsonObjectMemberIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const PicoJsonObjectMemberIterator& operator--(int)
     {
         itr--;
+
+		return *this;
     }
 
 private:

--- a/include/valijson/adapters/picojson_adapter.hpp
+++ b/include/valijson/adapters/picojson_adapter.hpp
@@ -295,10 +295,10 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<PicoJsonArray> getArrayOptional() const
+    opt::optional<PicoJsonArray> getArrayOptional() const
     {
         if (value.is<picojson::array>()) {
-			return opt::make_optional(PicoJsonArray(value));
+            return opt::make_optional(PicoJsonArray(value));
         }
 
         return opt::optional<PicoJsonArray>();
@@ -365,10 +365,10 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<PicoJsonObject> getObjectOptional() const
+    opt::optional<PicoJsonObject> getObjectOptional() const
     {
         if (value.is<picojson::object>()) {
-			return opt::make_optional(PicoJsonObject(value));
+            return opt::make_optional(PicoJsonObject(value));
         }
 
         return opt::optional<PicoJsonObject>();
@@ -506,7 +506,7 @@ public:
  */
 class PicoJsonArrayValueIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        std::bidirectional_iterator_tag,     // bi-directional iterator
         PicoJsonAdapter>                     // value type
 {
 public:
@@ -528,10 +528,10 @@ public:
         return PicoJsonAdapter(*itr);
     }
 
-	DerefProxy<PicoJsonAdapter> operator->() const
-	{
-		return DerefProxy<PicoJsonAdapter>(**this);
-	}
+    DerefProxy<PicoJsonAdapter> operator->() const
+    {
+        return DerefProxy<PicoJsonAdapter>(**this);
+    }
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -549,31 +549,31 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const PicoJsonArrayValueIterator &other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const PicoJsonArrayValueIterator &other) const
+    {
+        return !(itr == other.itr);
+    }
 
     const PicoJsonArrayValueIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	PicoJsonArrayValueIterator operator++(int)
-	{
-		PicoJsonArrayValueIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    PicoJsonArrayValueIterator operator++(int)
+    {
+        PicoJsonArrayValueIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const PicoJsonArrayValueIterator& operator--()
-	{
-		itr--;
+    const PicoJsonArrayValueIterator& operator--()
+    {
+        itr--;
 
-		return *this;
-	}
+        return *this;
+    }
 
     void advance(std::ptrdiff_t n)
     {
@@ -597,7 +597,7 @@ private:
  */
 class PicoJsonObjectMemberIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,  // bi-directional iterator
+        std::bidirectional_iterator_tag,  // bi-directional iterator
         PicoJsonObjectMember>             // value type
 {
 public:
@@ -620,10 +620,10 @@ public:
         return PicoJsonObjectMember(itr->first, itr->second);
     }
 
-	DerefProxy<PicoJsonObjectMember> operator->() const
-	{
-		return DerefProxy<PicoJsonObjectMember>(**this);
-	}
+    DerefProxy<PicoJsonObjectMember> operator->() const
+    {
+        return DerefProxy<PicoJsonObjectMember>(**this);
+    }
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -641,30 +641,30 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const PicoJsonObjectMemberIterator &other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const PicoJsonObjectMemberIterator &other) const
+    {
+        return !(itr == other.itr);
+    }
 
     const PicoJsonObjectMemberIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	PicoJsonObjectMemberIterator operator++(int)
-	{
-		PicoJsonObjectMemberIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    PicoJsonObjectMemberIterator operator++(int)
+    {
+        PicoJsonObjectMemberIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const PicoJsonObjectMemberIterator& operator--(int)
+    const PicoJsonObjectMemberIterator& operator--(int)
     {
         itr--;
 
-		return *this;
+        return *this;
     }
 
 private:

--- a/include/valijson/adapters/picojson_adapter.hpp
+++ b/include/valijson/adapters/picojson_adapter.hpp
@@ -293,18 +293,18 @@ public:
      * @brief   Optionally return a PicoJsonArray instance.
      *
      * If the referenced PicoJson value is an array, this function will return
-     * a boost::optional containing a PicoJsonArray instance referencing the
+     * a std::optional containing a PicoJsonArray instance referencing the
      * array.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<PicoJsonArray> getArrayOptional() const
+	std::experimental::optional<PicoJsonArray> getArrayOptional() const
     {
         if (value.is<picojson::array>()) {
-            return boost::make_optional(PicoJsonArray(value));
+			return std::experimental::make_optional(PicoJsonArray(value));
         }
 
-        return boost::none;
+        return std::experimental::optional<PicoJsonArray>();
     }
 
     /**
@@ -363,18 +363,18 @@ public:
      * @brief   Optionally return a PicoJsonObject instance.
      *
      * If the referenced PicoJson value is an object, this function will return a
-     * boost::optional containing a PicoJsonObject instance referencing the
+     * std::optional containing a PicoJsonObject instance referencing the
      * object.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<PicoJsonObject> getObjectOptional() const
+	std::experimental::optional<PicoJsonObject> getObjectOptional() const
     {
         if (value.is<picojson::object>()) {
-            return boost::make_optional(PicoJsonObject(value));
+			return std::experimental::make_optional(PicoJsonObject(value));
         }
 
-        return boost::none;
+        return std::experimental::optional<PicoJsonObject>();
     }
 
     /**

--- a/include/valijson/adapters/picojson_adapter.hpp
+++ b/include/valijson/adapters/picojson_adapter.hpp
@@ -509,17 +509,6 @@ class PicoJsonArrayValueIterator:
 	    std::bidirectional_iterator_tag,     // bi-directional iterator
         PicoJsonAdapter>                     // value type
 {
-private:
-
-	struct proxy
-	{
-		explicit proxy(const PicoJsonAdapter& x) : m_ref(x) {}
-		PicoJsonAdapter* operator->() { return std::addressof(m_ref); }
-		operator PicoJsonAdapter*() { return std::addressof(m_ref); }
-
-		PicoJsonAdapter m_ref;
-	};
-
 public:
 
     /**
@@ -539,9 +528,9 @@ public:
         return PicoJsonAdapter(*itr);
     }
 
-	proxy operator->() const
+	DerefProxy<PicoJsonAdapter> operator->() const
 	{
-		return proxy(**this);
+		return DerefProxy<PicoJsonAdapter>(**this);
 	}
 
     /**
@@ -611,17 +600,6 @@ class PicoJsonObjectMemberIterator:
 	    std::bidirectional_iterator_tag,  // bi-directional iterator
         PicoJsonObjectMember>             // value type
 {
-private:
-
-	struct proxy
-	{
-		explicit proxy(const PicoJsonObjectMember& x) : m_ref(x) {}
-		PicoJsonObjectMember* operator->() { return std::addressof(m_ref); }
-		operator PicoJsonObjectMember*() { return std::addressof(m_ref); }
-
-		PicoJsonObjectMember m_ref;
-	};
-
 public:
 
     /**
@@ -642,9 +620,9 @@ public:
         return PicoJsonObjectMember(itr->first, itr->second);
     }
 
-	proxy operator->() const
+	DerefProxy<PicoJsonObjectMember> operator->() const
 	{
-		return proxy(**this);
+		return DerefProxy<PicoJsonObjectMember>(**this);
 	}
 
     /**

--- a/include/valijson/adapters/picojson_adapter.hpp
+++ b/include/valijson/adapters/picojson_adapter.hpp
@@ -500,7 +500,7 @@ public:
  *
  * This class provides a JSON array iterator that dereferences as an instance of
  * PicoJsonAdapter representing a value stored in the array. It has been
- * implemented using the boost iterator_facade template.
+ * implemented using the std::iterator template.
  *
  * @see PicoJsonArray
  */

--- a/include/valijson/adapters/picojson_adapter.hpp
+++ b/include/valijson/adapters/picojson_adapter.hpp
@@ -298,13 +298,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<PicoJsonArray> getArrayOptional() const
+	opt::optional<PicoJsonArray> getArrayOptional() const
     {
         if (value.is<picojson::array>()) {
-			return std::experimental::make_optional(PicoJsonArray(value));
+			return opt::make_optional(PicoJsonArray(value));
         }
 
-        return std::experimental::optional<PicoJsonArray>();
+        return opt::optional<PicoJsonArray>();
     }
 
     /**
@@ -368,13 +368,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<PicoJsonObject> getObjectOptional() const
+	opt::optional<PicoJsonObject> getObjectOptional() const
     {
         if (value.is<picojson::object>()) {
-			return std::experimental::make_optional(PicoJsonObject(value));
+			return opt::make_optional(PicoJsonObject(value));
         }
 
-        return std::experimental::optional<PicoJsonObject>();
+        return opt::optional<PicoJsonObject>();
     }
 
     /**

--- a/include/valijson/adapters/property_tree_adapter.hpp
+++ b/include/valijson/adapters/property_tree_adapter.hpp
@@ -524,11 +524,9 @@ public:
  * @see PropertyTreeArray
  */
 class PropertyTreeArrayValueIterator:
-    public boost::iterator_facade<
-        PropertyTreeArrayValueIterator,      // name of derived type
-        PropertyTreeAdapter,                 // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        PropertyTreeAdapter>                 // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,    // bi-directional iterator
+        PropertyTreeAdapter>                // value type
 {
 public:
 
@@ -544,10 +542,15 @@ public:
 
     /// Returns a PropertyTreeAdapter that contains the value of the current
     /// element.
-    PropertyTreeAdapter dereference() const
+    PropertyTreeAdapter operator*() const
     {
         return PropertyTreeAdapter(itr->second);
     }
+
+	DerefProxy<PropertyTreeAdapter> operator->() const
+	{
+		return DerefProxy<PropertyTreeAdapter>(**this);
+	}
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -560,20 +563,36 @@ public:
      *
      * @returns true if the iterators are equal, false otherwise.
      */
-    bool equal(const PropertyTreeArrayValueIterator &rhs) const
+    bool operator==(const PropertyTreeArrayValueIterator &rhs) const
     {
         return itr == rhs.itr;
     }
 
-    void increment()
+	bool operator!=(const PropertyTreeArrayValueIterator &rhs) const
+	{
+		return !(itr == rhs.itr);
+	}
+
+    const PropertyTreeArrayValueIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
-    {
-        itr--;
-    }
+	PropertyTreeArrayValueIterator operator++(int)
+	{
+		PropertyTreeArrayValueIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const PropertyTreeArrayValueIterator& operator--()
+	{
+		itr--;
+
+		return *this;
+	}
 
     void advance(std::ptrdiff_t n)
     {

--- a/include/valijson/adapters/property_tree_adapter.hpp
+++ b/include/valijson/adapters/property_tree_adapter.hpp
@@ -329,10 +329,10 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<PropertyTreeArray> getArrayOptional() const
+    opt::optional<PropertyTreeArray> getArrayOptional() const
     {
         if (array) {
-			return opt::make_optional(PropertyTreeArray(*array));
+            return opt::make_optional(PropertyTreeArray(*array));
         }
 
         return opt::optional<PropertyTreeArray>();
@@ -383,10 +383,10 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<PropertyTreeObject> getObjectOptional() const
+    opt::optional<PropertyTreeObject> getObjectOptional() const
     {
         if (object) {
-			return opt::make_optional(PropertyTreeObject(*object));
+            return opt::make_optional(PropertyTreeObject(*object));
         }
 
         return opt::optional<PropertyTreeObject>();
@@ -430,7 +430,7 @@ public:
 
     bool isArray() const
     {
-		return static_cast<bool>(array);
+        return static_cast<bool>(array);
     }
 
     bool isBool() const
@@ -460,7 +460,7 @@ public:
 
     bool isObject() const
     {
-		return static_cast<bool>(object);
+        return static_cast<bool>(object);
     }
 
     bool isString() const
@@ -477,13 +477,13 @@ private:
     }
 
     /// Reference used if the value is known to be an array
-	opt::optional<const boost::property_tree::ptree &> array;
+    opt::optional<const boost::property_tree::ptree &> array;
 
     /// Reference used if the value is known to be an object
     opt::optional<const boost::property_tree::ptree &> object;
 
     /// Reference used if the value is known to be a POD type
-	opt::optional<std::string> value;
+    opt::optional<std::string> value;
 };
 
 /**
@@ -525,7 +525,7 @@ public:
  */
 class PropertyTreeArrayValueIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,    // bi-directional iterator
+        std::bidirectional_iterator_tag,    // bi-directional iterator
         PropertyTreeAdapter>                // value type
 {
 public:
@@ -547,10 +547,10 @@ public:
         return PropertyTreeAdapter(itr->second);
     }
 
-	DerefProxy<PropertyTreeAdapter> operator->() const
-	{
-		return DerefProxy<PropertyTreeAdapter>(**this);
-	}
+    DerefProxy<PropertyTreeAdapter> operator->() const
+    {
+        return DerefProxy<PropertyTreeAdapter>(**this);
+    }
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -568,31 +568,31 @@ public:
         return itr == rhs.itr;
     }
 
-	bool operator!=(const PropertyTreeArrayValueIterator &rhs) const
-	{
-		return !(itr == rhs.itr);
-	}
+    bool operator!=(const PropertyTreeArrayValueIterator &rhs) const
+    {
+        return !(itr == rhs.itr);
+    }
 
     const PropertyTreeArrayValueIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	PropertyTreeArrayValueIterator operator++(int)
-	{
-		PropertyTreeArrayValueIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    PropertyTreeArrayValueIterator operator++(int)
+    {
+        PropertyTreeArrayValueIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const PropertyTreeArrayValueIterator& operator--()
-	{
-		itr--;
+    const PropertyTreeArrayValueIterator& operator--()
+    {
+        itr--;
 
-		return *this;
-	}
+        return *this;
+    }
 
     void advance(std::ptrdiff_t n)
     {
@@ -624,7 +624,7 @@ private:
  */
 class PropertyTreeObjectMemberIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        std::bidirectional_iterator_tag,     // bi-directional iterator
         PropertyTreeObjectMember>            // value type
 {
 public:
@@ -647,10 +647,10 @@ public:
         return PropertyTreeObjectMember(itr->first, itr->second);
     }
 
-	DerefProxy<PropertyTreeObjectMember> operator->() const
-	{
-		return DerefProxy<PropertyTreeObjectMember>(**this);
-	}
+    DerefProxy<PropertyTreeObjectMember> operator->() const
+    {
+        return DerefProxy<PropertyTreeObjectMember>(**this);
+    }
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -668,31 +668,31 @@ public:
         return itr == rhs.itr;
     }
 
-	bool operator!=(const PropertyTreeObjectMemberIterator &rhs) const
-	{
-		return !(itr == rhs.itr);
-	}
+    bool operator!=(const PropertyTreeObjectMemberIterator &rhs) const
+    {
+        return !(itr == rhs.itr);
+    }
 
     const PropertyTreeObjectMemberIterator& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	PropertyTreeObjectMemberIterator operator++(int)
-	{
-		PropertyTreeObjectMemberIterator iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    PropertyTreeObjectMemberIterator operator++(int)
+    {
+        PropertyTreeObjectMemberIterator iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	const PropertyTreeObjectMemberIterator& operator--()
-	{
-		itr++;
+    const PropertyTreeObjectMemberIterator& operator--()
+    {
+        itr++;
 
-		return *this;
-	}
+        return *this;
+    }
 
 private:
 

--- a/include/valijson/adapters/property_tree_adapter.hpp
+++ b/include/valijson/adapters/property_tree_adapter.hpp
@@ -330,13 +330,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<PropertyTreeArray> getArrayOptional() const
+	opt::optional<PropertyTreeArray> getArrayOptional() const
     {
         if (array) {
-			return std::experimental::make_optional(PropertyTreeArray(*array));
+			return opt::make_optional(PropertyTreeArray(*array));
         }
 
-        return std::experimental::optional<PropertyTreeArray>();
+        return opt::optional<PropertyTreeArray>();
     }
 
     /**
@@ -384,13 +384,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<PropertyTreeObject> getObjectOptional() const
+	opt::optional<PropertyTreeObject> getObjectOptional() const
     {
         if (object) {
-			return std::experimental::make_optional(PropertyTreeObject(*object));
+			return opt::make_optional(PropertyTreeObject(*object));
         }
 
-        return std::experimental::optional<PropertyTreeObject>();
+        return opt::optional<PropertyTreeObject>();
     }
 
     /**
@@ -478,13 +478,13 @@ private:
     }
 
     /// Reference used if the value is known to be an array
-	std::experimental::optional<const boost::property_tree::ptree &> array;
+	opt::optional<const boost::property_tree::ptree &> array;
 
     /// Reference used if the value is known to be an object
-    std::experimental::optional<const boost::property_tree::ptree &> object;
+    opt::optional<const boost::property_tree::ptree &> object;
 
     /// Reference used if the value is known to be a POD type
-	std::experimental::optional<std::string> value;
+	opt::optional<std::string> value;
 };
 
 /**

--- a/include/valijson/adapters/property_tree_adapter.hpp
+++ b/include/valijson/adapters/property_tree_adapter.hpp
@@ -28,8 +28,7 @@
 #define __VALIJSON_ADAPTERS_PROPERTY_TREE_ADAPTER_HPP
 
 #include <string>
-#include <boost/bind.hpp>
-#include <boost/iterator/iterator_facade.hpp>
+
 #include <boost/property_tree/ptree.hpp>
 
 #include <valijson/adapters/adapter.hpp>

--- a/include/valijson/adapters/property_tree_adapter.hpp
+++ b/include/valijson/adapters/property_tree_adapter.hpp
@@ -281,7 +281,7 @@ public:
     {
         if (tree.data().empty()) {    // No string content
             if (tree.size() == 0) {   // No children
-                array = tree;         // Treat as empty array
+                array.emplace(tree);         // Treat as empty array
             } else {
                 bool isArray = true;
                 boost::property_tree::ptree::const_iterator itr;
@@ -293,9 +293,9 @@ public:
                 }
 
                 if (isArray) {
-                    array = tree;
+                    array.emplace(tree);
                 } else {
-                    object = tree;
+                    object.emplace(tree);
                 }
             }
         } else {
@@ -325,18 +325,18 @@ public:
      * @brief  Return an instance of PropertyTreeArrayAdapter.
      *
      * If the referenced property tree value is an array, this function will
-     * return a boost::optional containing a PropertyTreeArray instance
+     * return a std::optional containing a PropertyTreeArray instance
      * referencing the array.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<PropertyTreeArray> getArrayOptional() const
+	std::experimental::optional<PropertyTreeArray> getArrayOptional() const
     {
         if (array) {
-            return boost::make_optional(PropertyTreeArray(*array));
+			return std::experimental::make_optional(PropertyTreeArray(*array));
         }
 
-        return boost::none;
+        return std::experimental::optional<PropertyTreeArray>();
     }
 
     /**
@@ -379,18 +379,18 @@ public:
      * @brief   Optionally return a PropertyTreeObject instance.
      *
      * If the referenced property tree is an object, this function will return a
-     * boost::optional containing a PropertyTreeObject instance referencing the
+     * std::optional containing a PropertyTreeObject instance referencing the
      * object.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<PropertyTreeObject> getObjectOptional() const
+	std::experimental::optional<PropertyTreeObject> getObjectOptional() const
     {
         if (object) {
-            return boost::make_optional(PropertyTreeObject(*object));
+			return std::experimental::make_optional(PropertyTreeObject(*object));
         }
 
-        return boost::none;
+        return std::experimental::optional<PropertyTreeObject>();
     }
 
     /**
@@ -431,7 +431,7 @@ public:
 
     bool isArray() const
     {
-        return array != boost::none;
+		return static_cast<bool>(array);
     }
 
     bool isBool() const
@@ -461,12 +461,12 @@ public:
 
     bool isObject() const
     {
-        return object != boost::none;
+		return static_cast<bool>(object);
     }
 
     bool isString() const
     {
-        return value != boost::none;
+        return static_cast<bool>(value);
     }
 
 private:
@@ -478,13 +478,13 @@ private:
     }
 
     /// Reference used if the value is known to be an array
-    boost::optional<const boost::property_tree::ptree &> array;
+	std::experimental::optional<const boost::property_tree::ptree &> array;
 
     /// Reference used if the value is known to be an object
-    boost::optional<const boost::property_tree::ptree &> object;
+    std::experimental::optional<const boost::property_tree::ptree &> object;
 
     /// Reference used if the value is known to be a POD type
-    boost::optional<std::string> value;
+	std::experimental::optional<std::string> value;
 };
 
 /**

--- a/include/valijson/adapters/property_tree_adapter.hpp
+++ b/include/valijson/adapters/property_tree_adapter.hpp
@@ -623,11 +623,9 @@ private:
  * @see PropertyTreeObjectMember
  */
 class PropertyTreeObjectMemberIterator:
-    public boost::iterator_facade<
-        PropertyTreeObjectMemberIterator,    // name of derived type
-        PropertyTreeObjectMember,            // value type
-        boost::bidirectional_traversal_tag,  // bi-directional iterator
-        PropertyTreeObjectMember>            // type returned when dereferenced
+    public std::iterator<
+	    std::bidirectional_iterator_tag,     // bi-directional iterator
+        PropertyTreeObjectMember>            // value type
 {
 public:
 
@@ -644,10 +642,15 @@ public:
      * @brief   Returns a PropertyTreeObjectMember that contains the key and
      *          value belonging to the object member identified by the iterator.
      */
-    PropertyTreeObjectMember dereference() const
+    PropertyTreeObjectMember operator*() const
     {
         return PropertyTreeObjectMember(itr->first, itr->second);
     }
+
+	DerefProxy<PropertyTreeObjectMember> operator->() const
+	{
+		return DerefProxy<PropertyTreeObjectMember>(**this);
+	}
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -660,20 +663,36 @@ public:
      *
      * @returns true if the underlying iterators are equal, false otherwise
      */
-    bool equal(const PropertyTreeObjectMemberIterator &rhs) const
+    bool operator==(const PropertyTreeObjectMemberIterator &rhs) const
     {
         return itr == rhs.itr;
     }
 
-    void increment()
+	bool operator!=(const PropertyTreeObjectMemberIterator &rhs) const
+	{
+		return !(itr == rhs.itr);
+	}
+
+    const PropertyTreeObjectMemberIterator& operator++()
     {
         itr++;
+
+		return *this;
     }
 
-    void decrement()
-    {
-        itr--;
-    }
+	PropertyTreeObjectMemberIterator operator++(int)
+	{
+		PropertyTreeObjectMemberIterator iterator_pre(itr);
+		++(*this);
+		return iterator_pre;
+	}
+
+	const PropertyTreeObjectMemberIterator& operator--()
+	{
+		itr++;
+
+		return *this;
+	}
 
 private:
 

--- a/include/valijson/adapters/rapidjson_adapter.hpp
+++ b/include/valijson/adapters/rapidjson_adapter.hpp
@@ -408,13 +408,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<GenericRapidJsonArray<ValueType> > getArrayOptional() const
+	opt::optional<GenericRapidJsonArray<ValueType> > getArrayOptional() const
     {
         if (value.IsArray()) {
-			return std::experimental::make_optional(GenericRapidJsonArray<ValueType>(value));
+			return opt::make_optional(GenericRapidJsonArray<ValueType>(value));
         }
 
-        return std::experimental::optional<GenericRapidJsonArray<ValueType> >();
+        return opt::optional<GenericRapidJsonArray<ValueType> >();
     }
 
     /**
@@ -486,13 +486,13 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	std::experimental::optional<GenericRapidJsonObject<ValueType> > getObjectOptional() const
+	opt::optional<GenericRapidJsonObject<ValueType> > getObjectOptional() const
     {
         if (value.IsObject()) {
-            return std::experimental::make_optional(GenericRapidJsonObject<ValueType>(value));
+            return opt::make_optional(GenericRapidJsonObject<ValueType>(value));
         }
 
-        return std::experimental::optional<GenericRapidJsonObject<ValueType> >();
+        return opt::optional<GenericRapidJsonObject<ValueType> >();
     }
 
     /**

--- a/include/valijson/adapters/rapidjson_adapter.hpp
+++ b/include/valijson/adapters/rapidjson_adapter.hpp
@@ -406,10 +406,10 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<GenericRapidJsonArray<ValueType> > getArrayOptional() const
+    opt::optional<GenericRapidJsonArray<ValueType> > getArrayOptional() const
     {
         if (value.IsArray()) {
-			return opt::make_optional(GenericRapidJsonArray<ValueType>(value));
+            return opt::make_optional(GenericRapidJsonArray<ValueType>(value));
         }
 
         return opt::optional<GenericRapidJsonArray<ValueType> >();
@@ -484,7 +484,7 @@ public:
      *
      * Otherwise it will return an empty optional.
      */
-	opt::optional<GenericRapidJsonObject<ValueType> > getObjectOptional() const
+    opt::optional<GenericRapidJsonObject<ValueType> > getObjectOptional() const
     {
         if (value.IsObject()) {
             return opt::make_optional(GenericRapidJsonObject<ValueType>(value));
@@ -631,8 +631,8 @@ public:
 template<class ValueType>
 class GenericRapidJsonArrayValueIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,                 // bi-directional iterator
-	    GenericRapidJsonAdapter<ValueType> >             // value type
+        std::bidirectional_iterator_tag,                 // bi-directional iterator
+        GenericRapidJsonAdapter<ValueType> >             // value type
 {
 public:
 
@@ -653,11 +653,11 @@ public:
         return GenericRapidJsonAdapter<ValueType>(*itr);
     }
 
-	/// Returns a proxy for the value of the current element
-	DerefProxy<GenericRapidJsonAdapter<ValueType> > operator->() const
-	{
-		return DerefProxy<GenericRapidJsonAdapter<ValueType> >(**this);
-	}
+    /// Returns a proxy for the value of the current element
+    DerefProxy<GenericRapidJsonAdapter<ValueType> > operator->() const
+    {
+        return DerefProxy<GenericRapidJsonAdapter<ValueType> >(**this);
+    }
 
     /**
      * @brief   Compare this iterator against another iterator.
@@ -675,29 +675,29 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const GenericRapidJsonArrayValueIterator<ValueType>& other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const GenericRapidJsonArrayValueIterator<ValueType>& other) const
+    {
+        return !(itr == other.itr);
+    }
 
     GenericRapidJsonArrayValueIterator<ValueType>& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	GenericRapidJsonArrayValueIterator<ValueType> operator++(int) {
-		GenericRapidJsonArrayValueIterator<ValueType> iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    GenericRapidJsonArrayValueIterator<ValueType> operator++(int) {
+        GenericRapidJsonArrayValueIterator<ValueType> iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
-	GenericRapidJsonArrayValueIterator<ValueType>& operator--()
+    GenericRapidJsonArrayValueIterator<ValueType>& operator--()
     {
         itr--;
 
-		return *this;
+        return *this;
     }
 
     void advance(std::ptrdiff_t n)
@@ -728,7 +728,7 @@ private:
 template<class ValueType>
 class GenericRapidJsonObjectMemberIterator:
     public std::iterator<
-	    std::bidirectional_iterator_tag,                 // bi-directional iterator
+        std::bidirectional_iterator_tag,                 // bi-directional iterator
         GenericRapidJsonObjectMember<ValueType> >        // value type
 {
 public:
@@ -754,11 +754,11 @@ public:
             itr->value);
     }
 
-	/// Returns a proxy for the value of the current element
-	DerefProxy<GenericRapidJsonObjectMember<ValueType> > operator->() const
-	{
-		return DerefProxy<GenericRapidJsonObjectMember<ValueType> >(**this);
-	}
+    /// Returns a proxy for the value of the current element
+    DerefProxy<GenericRapidJsonObjectMember<ValueType> > operator->() const
+    {
+        return DerefProxy<GenericRapidJsonObjectMember<ValueType> >(**this);
+    }
 
     /**
      * @brief   Compare this iterator with another iterator.
@@ -776,30 +776,30 @@ public:
         return itr == other.itr;
     }
 
-	bool operator!=(const GenericRapidJsonObjectMemberIterator<ValueType> &other) const
-	{
-		return !(itr == other.itr);
-	}
+    bool operator!=(const GenericRapidJsonObjectMemberIterator<ValueType> &other) const
+    {
+        return !(itr == other.itr);
+    }
 
     GenericRapidJsonObjectMemberIterator<ValueType>& operator++()
     {
         itr++;
 
-		return *this;
+        return *this;
     }
 
-	GenericRapidJsonObjectMemberIterator<ValueType> operator++(int)
-	{
-		GenericRapidJsonObjectMemberIterator<ValueType> iterator_pre(itr);
-		++(*this);
-		return iterator_pre;
-	}
+    GenericRapidJsonObjectMemberIterator<ValueType> operator++(int)
+    {
+        GenericRapidJsonObjectMemberIterator<ValueType> iterator_pre(itr);
+        ++(*this);
+        return iterator_pre;
+    }
 
     GenericRapidJsonObjectMemberIterator<ValueType>& operator--()
     {
         itr--;
 
-		return *this;
+        return *this;
     }
 
     std::ptrdiff_t difference(const GenericRapidJsonObjectMemberIterator &other)

--- a/include/valijson/adapters/rapidjson_adapter.hpp
+++ b/include/valijson/adapters/rapidjson_adapter.hpp
@@ -634,17 +634,6 @@ class GenericRapidJsonArrayValueIterator:
 	    std::bidirectional_iterator_tag,                 // bi-directional iterator
 	    GenericRapidJsonAdapter<ValueType> >             // value type
 {
-private:
-
-	struct proxy
-	{
-		explicit proxy(const GenericRapidJsonAdapter<ValueType>& x) : m_ref(x) {}
-		GenericRapidJsonAdapter<ValueType>* operator->() { return std::addressof(m_ref); }
-		operator GenericRapidJsonAdapter<ValueType>*() { return std::addressof(m_ref); }
-
-		GenericRapidJsonAdapter<ValueType> m_ref;
-	};
-
 public:
 
     /**
@@ -665,9 +654,9 @@ public:
     }
 
 	/// Returns a proxy for the value of the current element
-	proxy operator->() const
+	DerefProxy<GenericRapidJsonAdapter<ValueType> > operator->() const
 	{
-		return proxy(**this);
+		return DerefProxy<GenericRapidJsonAdapter<ValueType> >(**this);
 	}
 
     /**
@@ -742,17 +731,6 @@ class GenericRapidJsonObjectMemberIterator:
 	    std::bidirectional_iterator_tag,                 // bi-directional iterator
         GenericRapidJsonObjectMember<ValueType> >        // value type
 {
-private:
-
-	struct proxy
-	{
-		explicit proxy(const GenericRapidJsonObjectMember<ValueType>& x) : m_ref(x) {}
-		GenericRapidJsonObjectMember<ValueType>* operator->() { return std::addressof(m_ref); }
-		operator GenericRapidJsonObjectMember<ValueType>*() { return std::addressof(m_ref); }
-
-		GenericRapidJsonObjectMember<ValueType> m_ref;
-	};
-
 public:
 
     /**
@@ -777,9 +755,9 @@ public:
     }
 
 	/// Returns a proxy for the value of the current element
-	proxy operator->() const
+	DerefProxy<GenericRapidJsonObjectMember<ValueType> > operator->() const
 	{
-		return proxy(**this);
+		return DerefProxy<GenericRapidJsonObjectMember<ValueType> >(**this);
 	}
 
     /**

--- a/include/valijson/adapters/rapidjson_adapter.hpp
+++ b/include/valijson/adapters/rapidjson_adapter.hpp
@@ -403,18 +403,18 @@ public:
      * @brief   Optionally return a GenericRapidJsonArray instance.
      *
      * If the referenced RapidJson value is an array, this function will return
-     * a boost::optional containing a GenericRapidJsonArray instance referencing
+     * a std::optional containing a GenericRapidJsonArray instance referencing
      * the array.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<GenericRapidJsonArray<ValueType> > getArrayOptional() const
+	std::experimental::optional<GenericRapidJsonArray<ValueType> > getArrayOptional() const
     {
         if (value.IsArray()) {
-            return boost::make_optional(GenericRapidJsonArray<ValueType>(value));
+			return std::experimental::make_optional(GenericRapidJsonArray<ValueType>(value));
         }
 
-        return boost::none;
+        return std::experimental::optional<GenericRapidJsonArray<ValueType> >();
     }
 
     /**
@@ -481,18 +481,18 @@ public:
      * @brief   Optionally return a GenericRapidJsonObject instance.
      *
      * If the referenced RapidJson value is an object, this function will return
-     * a boost::optional containing a GenericRapidJsonObject instance
+     * a std::optional containing a GenericRapidJsonObject instance
      * referencing the object.
      *
-     * Otherwise it will return boost::none.
+     * Otherwise it will return an empty optional.
      */
-    boost::optional<GenericRapidJsonObject<ValueType> > getObjectOptional() const
+	std::experimental::optional<GenericRapidJsonObject<ValueType> > getObjectOptional() const
     {
         if (value.IsObject()) {
-            return boost::make_optional(GenericRapidJsonObject<ValueType>(value));
+            return std::experimental::make_optional(GenericRapidJsonObject<ValueType>(value));
         }
 
-        return boost::none;
+        return std::experimental::optional<GenericRapidJsonObject<ValueType> >();
     }
 
     /**

--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -60,7 +60,7 @@ public:
     void applyToSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-        BOOST_FOREACH( const Subschema *subschema, subschemas ) {
+		for( const Subschema *subschema : subschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -103,7 +103,7 @@ public:
     void applyToSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-        BOOST_FOREACH( const Subschema *subschema, subschemas ) {
+		for( const Subschema *subschema : subschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -170,7 +170,7 @@ public:
         }
 
         typedef typename ContainerType::value_type ValueType;
-        BOOST_FOREACH( const ValueType &dependencyName, dependencyNames ) {
+		for( const ValueType &dependencyName : dependencyNames ) {
             itr->second.insert(String(dependencyName.c_str(), allocator));
         }
 
@@ -196,7 +196,7 @@ public:
     template<typename FunctorType>
     void applyToPropertyDependencies(const FunctorType &fn) const
     {
-        BOOST_FOREACH( const PropertyDependencies::value_type &v,
+		for( const PropertyDependencies::value_type &v :
                 propertyDependencies ) {
             if (!fn(v.first, v.second)) {
                 return;
@@ -207,7 +207,7 @@ public:
     template<typename FunctorType>
     void applyToSchemaDependencies(const FunctorType &fn) const
     {
-        BOOST_FOREACH( const SchemaDependencies::value_type &v,
+		for( const SchemaDependencies::value_type &v :
                 schemaDependencies ) {
             if (!fn(v.first, v.second)) {
                 return;
@@ -254,7 +254,7 @@ public:
     {
         try {
             // Clone individual enum values
-            BOOST_FOREACH( const EnumValue *otherValue, other.enumValues ) {
+			for( const EnumValue *otherValue : other.enumValues ) {
                 const EnumValue *value = otherValue->clone();
                 try {
                     enumValues.push_back(value);
@@ -266,7 +266,7 @@ public:
 
         } catch (...) {
             // Delete values already added to constraint
-            BOOST_FOREACH( const EnumValue *value, enumValues ) {
+			for( const EnumValue *value : enumValues ) {
                 delete value;
             }
             throw;
@@ -275,7 +275,7 @@ public:
 
     virtual ~EnumConstraint()
     {
-        BOOST_FOREACH( const EnumValue *value, enumValues ) {
+		for( const EnumValue *value : enumValues ) {
             delete value;
         }
     }
@@ -295,7 +295,7 @@ public:
     template<typename FunctorType>
     void applyToValues(const FunctorType &fn) const
     {
-        BOOST_FOREACH( const EnumValue *value, enumValues ) {
+		for( const EnumValue *value : enumValues ) {
             if (!fn(*value)) {
                 return;
             }
@@ -345,7 +345,7 @@ public:
     void applyToItemSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-        BOOST_FOREACH( const Subschema *subschema, itemSubschemas ) {
+		for( const Subschema *subschema : itemSubschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -727,7 +727,7 @@ public:
     void applyToSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-        BOOST_FOREACH( const Subschema *subschema, subschemas ) {
+		for( const Subschema *subschema : subschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -870,7 +870,7 @@ public:
     void applyToPatternProperties(const FunctorType &fn) const
     {
         typedef typename PropertySchemaMap::value_type ValueType;
-        BOOST_FOREACH( const ValueType &value, patternProperties ) {
+		for( const ValueType &value : patternProperties ) {
             if (!fn(value.first, value.second)) {
                 return;
             }
@@ -881,7 +881,7 @@ public:
     void applyToProperties(const FunctorType &fn) const
     {
         typedef typename PropertySchemaMap::value_type ValueType;
-        BOOST_FOREACH( const ValueType &value, properties ) {
+		for( const ValueType &value : properties ) {
             if (!fn(value.first, value.second)) {
                 return;
             }
@@ -937,7 +937,7 @@ public:
     template<typename FunctorType>
     void applyToRequiredProperties(const FunctorType &fn) const
     {
-        BOOST_FOREACH( const String &propertyName, requiredProperties ) {
+		for( const String &propertyName : requiredProperties ) {
             if (!fn(propertyName)) {
                 return;
             }
@@ -1024,7 +1024,7 @@ public:
     template<typename FunctorType>
     void applyToNamedTypes(const FunctorType &fn) const
     {
-        BOOST_FOREACH( const JsonType namedType, namedTypes ) {
+		for( const JsonType namedType : namedTypes ) {
             if (!fn(namedType)) {
                 return;
             }
@@ -1035,7 +1035,7 @@ public:
     void applyToSchemaTypes(const FunctorType &fn) const
     {
         unsigned int index = 0;
-        BOOST_FOREACH( const Subschema *subschema, schemaTypes ) {
+		for( const Subschema *subschema : schemaTypes ) {
             if (!fn(index, subschema)) {
                 return;
             }

--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -57,7 +57,7 @@ public:
     void applyToSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-		for( const Subschema *subschema : subschemas ) {
+        for( const Subschema *subschema : subschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -100,7 +100,7 @@ public:
     void applyToSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-		for( const Subschema *subschema : subschemas ) {
+        for( const Subschema *subschema : subschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -167,7 +167,7 @@ public:
         }
 
         typedef typename ContainerType::value_type ValueType;
-		for( const ValueType &dependencyName : dependencyNames ) {
+        for( const ValueType &dependencyName : dependencyNames ) {
             itr->second.insert(String(dependencyName.c_str(), allocator));
         }
 
@@ -193,7 +193,7 @@ public:
     template<typename FunctorType>
     void applyToPropertyDependencies(const FunctorType &fn) const
     {
-		for( const PropertyDependencies::value_type &v :
+        for( const PropertyDependencies::value_type &v :
                 propertyDependencies ) {
             if (!fn(v.first, v.second)) {
                 return;
@@ -204,7 +204,7 @@ public:
     template<typename FunctorType>
     void applyToSchemaDependencies(const FunctorType &fn) const
     {
-		for( const SchemaDependencies::value_type &v :
+        for( const SchemaDependencies::value_type &v :
                 schemaDependencies ) {
             if (!fn(v.first, v.second)) {
                 return;
@@ -251,7 +251,7 @@ public:
     {
         try {
             // Clone individual enum values
-			for( const EnumValue *otherValue : other.enumValues ) {
+            for( const EnumValue *otherValue : other.enumValues ) {
                 const EnumValue *value = otherValue->clone();
                 try {
                     enumValues.push_back(value);
@@ -263,7 +263,7 @@ public:
 
         } catch (...) {
             // Delete values already added to constraint
-			for( const EnumValue *value : enumValues ) {
+            for( const EnumValue *value : enumValues ) {
                 delete value;
             }
             throw;
@@ -272,7 +272,7 @@ public:
 
     virtual ~EnumConstraint()
     {
-		for( const EnumValue *value : enumValues ) {
+        for( const EnumValue *value : enumValues ) {
             delete value;
         }
     }
@@ -292,7 +292,7 @@ public:
     template<typename FunctorType>
     void applyToValues(const FunctorType &fn) const
     {
-		for( const EnumValue *value : enumValues ) {
+        for( const EnumValue *value : enumValues ) {
             if (!fn(*value)) {
                 return;
             }
@@ -342,7 +342,7 @@ public:
     void applyToItemSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-		for( const Subschema *subschema : itemSubschemas ) {
+        for( const Subschema *subschema : itemSubschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -724,7 +724,7 @@ public:
     void applyToSubschemas(const FunctorType &fn) const
     {
         unsigned int index = 0;
-		for( const Subschema *subschema : subschemas ) {
+        for( const Subschema *subschema : subschemas ) {
             if (!fn(index, subschema)) {
                 return;
             }
@@ -867,7 +867,7 @@ public:
     void applyToPatternProperties(const FunctorType &fn) const
     {
         typedef typename PropertySchemaMap::value_type ValueType;
-		for( const ValueType &value : patternProperties ) {
+        for( const ValueType &value : patternProperties ) {
             if (!fn(value.first, value.second)) {
                 return;
             }
@@ -878,7 +878,7 @@ public:
     void applyToProperties(const FunctorType &fn) const
     {
         typedef typename PropertySchemaMap::value_type ValueType;
-		for( const ValueType &value : properties ) {
+        for( const ValueType &value : properties ) {
             if (!fn(value.first, value.second)) {
                 return;
             }
@@ -934,7 +934,7 @@ public:
     template<typename FunctorType>
     void applyToRequiredProperties(const FunctorType &fn) const
     {
-		for( const String &propertyName : requiredProperties ) {
+        for( const String &propertyName : requiredProperties ) {
             if (!fn(propertyName)) {
                 return;
             }
@@ -1021,7 +1021,7 @@ public:
     template<typename FunctorType>
     void applyToNamedTypes(const FunctorType &fn) const
     {
-		for( const JsonType namedType : namedTypes ) {
+        for( const JsonType namedType : namedTypes ) {
             if (!fn(namedType)) {
                 return;
             }
@@ -1032,7 +1032,7 @@ public:
     void applyToSchemaTypes(const FunctorType &fn) const
     {
         unsigned int index = 0;
-		for( const Subschema *subschema : schemaTypes ) {
+        for( const Subschema *subschema : schemaTypes ) {
             if (!fn(index, subschema)) {
                 return;
             }

--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -16,9 +16,6 @@
 #ifndef __VALIJSON_CONSTRAINTS_CONCRETE_CONSTRAINTS_HPP
 #define __VALIJSON_CONSTRAINTS_CONCRETE_CONSTRAINTS_HPP
 
-#include <boost/ptr_container/ptr_vector.hpp>
-#include <boost/variant.hpp>
-
 #include <limits>
 #include <map>
 #include <set>

--- a/include/valijson/internal/json_pointer.hpp
+++ b/include/valijson/internal/json_pointer.hpp
@@ -14,13 +14,30 @@ namespace opt = std;
 namespace opt = std::experimental;
 #endif
 
-#include <boost/algorithm/string/replace.hpp>
-
 #include <valijson/adapters/adapter.hpp>
 
 namespace valijson {
 namespace internal {
 namespace json_pointer {
+
+/**
+ * @brief   Replace all occurrences of `search` with `replace`. Modifies `subject` in place
+ *
+ * @param   subject  string to operate on
+ * @param   search   string to search
+ * @param   replace  replacement string
+ */
+
+inline void replace_all_inplace(std::string& subject, const char* search,
+								const char* replace)
+{
+	size_t pos = 0;
+
+	while((pos = subject.find(search, pos)) != std::string::npos) {
+		subject.replace(pos, strlen(search), replace);
+		pos += strlen(replace);
+	}
+}
 
 /**
  * @brief   Return the char value corresponding to a 2-digit hexadecimal string
@@ -84,8 +101,8 @@ inline std::string extractReferenceToken(std::string::const_iterator begin,
     std::string token(begin, end);
 
     // Replace JSON Pointer-specific escaped character sequences
-    boost::replace_all(token, "~1", "/");
-    boost::replace_all(token, "~0", "~");
+    replace_all_inplace(token, "~1", "/");
+    replace_all_inplace(token, "~0", "~");
 
     // Replace %-encoded character sequences with their actual characters
     for (size_t n = token.find('%'); n != std::string::npos;

--- a/include/valijson/internal/json_pointer.hpp
+++ b/include/valijson/internal/json_pointer.hpp
@@ -6,9 +6,15 @@
 #include <stdexcept>
 #include <string>
 
+#if __has_include(<optional>)
+#  include <optional>
+namespace opt = std;
+#else
+#  include <compat/optional.hpp>
+namespace opt = std::experimental;
+#endif
+
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
 
 #include <valijson/adapters/adapter.hpp>
 
@@ -169,8 +175,7 @@ inline AdapterType resolveJsonPointer(
 
         try {
             // Fragment must be non-negative integer
-            const uint64_t index = boost::lexical_cast<uint64_t>(
-                    referenceToken);
+			const uint64_t index = std::stoul(referenceToken);
             typedef typename AdapterType::Array Array;
             typename Array::const_iterator itr = node.asArray().begin();
 
@@ -182,7 +187,7 @@ inline AdapterType resolveJsonPointer(
 
             if (index > static_cast<uint64_t>(std::numeric_limits<ptrdiff_t>::max())) {
                 throw std::runtime_error("Array index out of bounds; hard "
-                        "limit is " + boost::lexical_cast<std::string>(
+                        "limit is " + std::to_string(
                                 std::numeric_limits<ptrdiff_t>::max()));
             }
 
@@ -191,7 +196,7 @@ inline AdapterType resolveJsonPointer(
             // Recursively process the remaining tokens
             return resolveJsonPointer(*itr, jsonPointer, jsonPointerNext);
 
-        } catch (boost::bad_lexical_cast &) {
+		} catch (std::invalid_argument &) {
             throw std::runtime_error("Expected reference token to contain a "
                     "non-negative integer to identify an element in the "
                     "current array; actual token: " + referenceToken);

--- a/include/valijson/internal/json_pointer.hpp
+++ b/include/valijson/internal/json_pointer.hpp
@@ -29,14 +29,14 @@ namespace json_pointer {
  */
 
 inline void replace_all_inplace(std::string& subject, const char* search,
-								const char* replace)
+                                const char* replace)
 {
-	size_t pos = 0;
+    size_t pos = 0;
 
-	while((pos = subject.find(search, pos)) != std::string::npos) {
-		subject.replace(pos, strlen(search), replace);
-		pos += strlen(replace);
-	}
+    while((pos = subject.find(search, pos)) != std::string::npos) {
+        subject.replace(pos, strlen(search), replace);
+        pos += strlen(replace);
+    }
 }
 
 /**
@@ -192,7 +192,7 @@ inline AdapterType resolveJsonPointer(
 
         try {
             // Fragment must be non-negative integer
-			const uint64_t index = std::stoul(referenceToken);
+            const uint64_t index = std::stoul(referenceToken);
             typedef typename AdapterType::Array Array;
             typename Array::const_iterator itr = node.asArray().begin();
 
@@ -213,7 +213,7 @@ inline AdapterType resolveJsonPointer(
             // Recursively process the remaining tokens
             return resolveJsonPointer(*itr, jsonPointer, jsonPointerNext);
 
-		} catch (std::invalid_argument &) {
+        } catch (std::invalid_argument &) {
             throw std::runtime_error("Expected reference token to contain a "
                     "non-negative integer to identify an element in the "
                     "current array; actual token: " + referenceToken);

--- a/include/valijson/internal/json_reference.hpp
+++ b/include/valijson/internal/json_reference.hpp
@@ -19,14 +19,14 @@ namespace json_reference {
      *
      * @return  Optional string containing URI
      */
-	inline std::experimental::optional<std::string> getJsonReferenceUri(
+	inline opt::optional<std::string> getJsonReferenceUri(
         const std::string &jsonRef)
     {
         const size_t ptrPos = jsonRef.find("#");
         if (ptrPos == 0) {
             // The JSON Reference does not contain a URI, but might contain a
             // JSON Pointer that refers to the current document
-			return std::experimental::optional<std::string>();
+			return opt::optional<std::string>();
         } else if (ptrPos != std::string::npos) {
             // The JSON Reference contains a URI and possibly a JSON Pointer
             return jsonRef.substr(0, ptrPos);
@@ -43,7 +43,7 @@ namespace json_reference {
      *
      * @return  Optional string containing JSON Pointer
      */
-	inline std::experimental::optional<std::string> getJsonReferencePointer(
+	inline opt::optional<std::string> getJsonReferencePointer(
         const std::string &jsonRef)
     {
         // Attempt to extract JSON Pointer if '#' character is present. Note
@@ -54,7 +54,7 @@ namespace json_reference {
             return jsonRef.substr(ptrPos + 1);
         }
 
-        return std::experimental::optional<std::string>();
+        return opt::optional<std::string>();
     }
 
 

--- a/include/valijson/internal/json_reference.hpp
+++ b/include/valijson/internal/json_reference.hpp
@@ -5,7 +5,13 @@
 #include <stdexcept>
 #include <string>
 
-#include <boost/optional.hpp>
+#if __has_include(<optional>)
+#  include <optional>
+namespace opt = std;
+#else
+#  include <compat/optional.hpp>
+namespace opt = std::experimental;
+#endif
 
 namespace valijson {
 namespace internal {

--- a/include/valijson/internal/json_reference.hpp
+++ b/include/valijson/internal/json_reference.hpp
@@ -25,14 +25,14 @@ namespace json_reference {
      *
      * @return  Optional string containing URI
      */
-	inline opt::optional<std::string> getJsonReferenceUri(
+    inline opt::optional<std::string> getJsonReferenceUri(
         const std::string &jsonRef)
     {
         const size_t ptrPos = jsonRef.find("#");
         if (ptrPos == 0) {
             // The JSON Reference does not contain a URI, but might contain a
             // JSON Pointer that refers to the current document
-			return opt::optional<std::string>();
+            return opt::optional<std::string>();
         } else if (ptrPos != std::string::npos) {
             // The JSON Reference contains a URI and possibly a JSON Pointer
             return jsonRef.substr(0, ptrPos);
@@ -49,7 +49,7 @@ namespace json_reference {
      *
      * @return  Optional string containing JSON Pointer
      */
-	inline opt::optional<std::string> getJsonReferencePointer(
+    inline opt::optional<std::string> getJsonReferencePointer(
         const std::string &jsonRef)
     {
         // Attempt to extract JSON Pointer if '#' character is present. Note

--- a/include/valijson/internal/json_reference.hpp
+++ b/include/valijson/internal/json_reference.hpp
@@ -19,14 +19,14 @@ namespace json_reference {
      *
      * @return  Optional string containing URI
      */
-    inline boost::optional<std::string> getJsonReferenceUri(
+	inline std::experimental::optional<std::string> getJsonReferenceUri(
         const std::string &jsonRef)
     {
         const size_t ptrPos = jsonRef.find("#");
         if (ptrPos == 0) {
             // The JSON Reference does not contain a URI, but might contain a
             // JSON Pointer that refers to the current document
-            return boost::none;
+			return std::experimental::optional<std::string>();
         } else if (ptrPos != std::string::npos) {
             // The JSON Reference contains a URI and possibly a JSON Pointer
             return jsonRef.substr(0, ptrPos);
@@ -43,7 +43,7 @@ namespace json_reference {
      *
      * @return  Optional string containing JSON Pointer
      */
-    inline boost::optional<std::string> getJsonReferencePointer(
+	inline std::experimental::optional<std::string> getJsonReferencePointer(
         const std::string &jsonRef)
     {
         // Attempt to extract JSON Pointer if '#' character is present. Note
@@ -54,7 +54,7 @@ namespace json_reference {
             return jsonRef.substr(ptrPos + 1);
         }
 
-        return boost::none;
+        return std::experimental::optional<std::string>();
     }
 
 

--- a/include/valijson/schema_parser.hpp
+++ b/include/valijson/schema_parser.hpp
@@ -174,7 +174,7 @@ private:
     {
         typedef typename DocumentCache<AdapterType>::Type DocCacheType;
 
-        BOOST_FOREACH( const typename DocCacheType::value_type &v, docCache ) {
+		for( const typename DocCacheType::value_type &v : docCache ) {
             freeDoc(v.second);
         }
     }
@@ -314,7 +314,7 @@ private:
             const std::vector<std::string> &keysToCreate,
             const Subschema *schema)
     {
-        BOOST_FOREACH( const std::string &keyToCreate, keysToCreate ) {
+		for( const std::string &keyToCreate : keysToCreate ) {
             const SchemaCache::value_type value(keyToCreate, schema);
             if (!schemaCache.insert(value).second) {
                 throw std::logic_error(
@@ -1039,7 +1039,7 @@ private:
         constraints::AllOfConstraint constraint;
 
         int index = 0;
-        BOOST_FOREACH ( const AdapterType schemaNode, node.asArray() ) {
+		for ( const AdapterType schemaNode : node.asArray() ) {
             if (schemaNode.maybeObject()) {
                 const std::string childPath = nodePath + "/" +
                         boost::lexical_cast<std::string>(index);
@@ -1095,7 +1095,7 @@ private:
         constraints::AnyOfConstraint constraint;
 
         int index = 0;
-        BOOST_FOREACH ( const AdapterType schemaNode, node.asArray() ) {
+		for ( const AdapterType schemaNode : node.asArray() ) {
             if (schemaNode.maybeObject()) {
                 const std::string childPath = nodePath + "/" +
                         boost::lexical_cast<std::string>(index);
@@ -1168,7 +1168,7 @@ private:
         constraints::DependenciesConstraint dependenciesConstraint;
 
         // Process each of the dependency mappings defined by the object
-        BOOST_FOREACH ( const typename AdapterType::ObjectMember member, node.asObject() ) {
+		for ( const typename AdapterType::ObjectMember member : node.asObject() ) {
 
             // First, we attempt to parse the value of the dependency mapping
             // as an array of strings. If the Adapter type does not support
@@ -1180,7 +1180,7 @@ private:
             if (member.second.maybeArray()) {
                 // Parse an array of dependency names
                 std::vector<std::string> dependentPropertyNames;
-                BOOST_FOREACH( const AdapterType dependencyName, member.second.asArray() ) {
+				for( const AdapterType dependencyName : member.second.asArray() ) {
                     if (dependencyName.maybeString()) {
                         dependentPropertyNames.push_back(dependencyName.getString());
                     } else {
@@ -1237,7 +1237,7 @@ private:
     {
         // Make a copy of each value in the enum array
         constraints::EnumConstraint constraint;
-        BOOST_FOREACH( const AdapterType value, node.getArray() ) {
+		for( const AdapterType value : node.getArray() ) {
             constraint.addValue(value);
         }
 
@@ -1335,7 +1335,7 @@ private:
                 // validate the values at the corresponding indexes in a target
                 // array.
                 int index = 0;
-                BOOST_FOREACH( const AdapterType v, items->getArray() ) {
+				for( const AdapterType v : items->getArray() ) {
                     const std::string childPath = itemsPath + "/" +
                             boost::lexical_cast<std::string>(index);
                     const Subschema *subschema = makeOrReuseSchema<AdapterType>(
@@ -1772,7 +1772,7 @@ private:
         constraints::OneOfConstraint constraint;
 
         int index = 0;
-        BOOST_FOREACH ( const AdapterType schemaNode, node.getArray() ) {
+		for ( const AdapterType schemaNode : node.getArray() ) {
             const std::string childPath = nodePath + "/" +
                     boost::lexical_cast<std::string>(index);
             const Subschema *subschema = makeOrReuseSchema<AdapterType>(
@@ -1861,7 +1861,7 @@ private:
 
         // Create subschemas for 'properties' constraint
         if (properties) {
-            BOOST_FOREACH( const Member m, properties->getObject() ) {
+			for( const Member m : properties->getObject() ) {
                 const std::string &property = m.first;
                 const std::string childPath = propertiesPath + "/" + property;
                 const Subschema *subschema = makeOrReuseSchema<AdapterType>(
@@ -1874,7 +1874,7 @@ private:
 
         // Create subschemas for 'patternProperties' constraint
         if (patternProperties) {
-            BOOST_FOREACH( const Member m, patternProperties->getObject() ) {
+			for( const Member m : patternProperties->getObject() ) {
                 const std::string &pattern = m.first;
                 const std::string childPath = patternPropertiesPath + "/" +
                         pattern;
@@ -1973,7 +1973,7 @@ private:
     {
         constraints::RequiredConstraint constraint;
 
-        BOOST_FOREACH( const AdapterType v, node.getArray() ) {
+		for( const AdapterType v : node.getArray() ) {
             if (!v.isString()) {
                 throw std::runtime_error("Expected required property name to "
                         "be a string value");
@@ -2030,7 +2030,7 @@ private:
 
         } else if (node.isArray()) {
             int index = 0;
-            BOOST_FOREACH( const AdapterType v, node.getArray() ) {
+			for( const AdapterType v : node.getArray() ) {
                 if (v.isString()) {
                     const TypeConstraint::JsonType type =
                             TypeConstraint::jsonTypeFromString(v.getString());

--- a/include/valijson/schema_parser.hpp
+++ b/include/valijson/schema_parser.hpp
@@ -135,7 +135,8 @@ public:
         typename DocumentCache<AdapterType>::Type docCache;
         SchemaCache schemaCache;
         try {
-            resolveThenPopulateSchema(schema, node, node, schema, boost::none, "",
+            resolveThenPopulateSchema(schema, node, node, schema,
+					std::experimental::optional<std::string>(), "",
                     fetchDoc, NULL, NULL, docCache, schemaCache);
         } catch (...) {
             freeDocumentCache<AdapterType>(docCache, freeDoc);
@@ -207,9 +208,9 @@ private:
      * document URI should be used to replace the path, query and fragment
      * portions of URI provided by the resolution scope.
      */
-    static boost::optional<std::string> findAbsoluteDocumentUri(
-            const boost::optional<std::string> resolutionScope,
-            const boost::optional<std::string> documentUri)
+	static std::experimental::optional<std::string> findAbsoluteDocumentUri(
+            const std::experimental::optional<std::string> resolutionScope,
+            const std::experimental::optional<std::string> documentUri)
     {
         if (resolutionScope) {
             if (documentUri) {
@@ -225,7 +226,7 @@ private:
         } else if (documentUri && internal::uri::isUriAbsolute(*documentUri)) {
             return *documentUri;
         } else {
-            return boost::none;
+            return std::experimental::optional<std::string>();
         }
     }
 
@@ -262,7 +263,7 @@ private:
     /**
      * Sanitise an optional JSON Pointer, trimming trailing slashes
      */
-    std::string sanitiseJsonPointer(const boost::optional<std::string> input)
+	std::string sanitiseJsonPointer(const std::experimental::optional<std::string> input)
     {
         if (input) {
             // Trim trailing slash(es)
@@ -363,7 +364,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+		const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -408,7 +409,7 @@ private:
 
         // Returns a document URI if the reference points somewhere
         // other than the current document
-        const boost::optional<std::string> documentUri =
+		const std::experimental::optional<std::string> documentUri =
                 internal::json_reference::getJsonReferenceUri(jsonRef);
 
         // Extract JSON Pointer from JSON Reference, with any trailing
@@ -421,7 +422,7 @@ private:
         // scope. An absolute document URI will take precedence when
         // present, otherwise we need to resolve the URI relative to
         // the current resolution scope
-        const boost::optional<std::string> actualDocumentUri =
+		const std::experimental::optional<std::string> actualDocumentUri =
                 findAbsoluteDocumentUri(currentScope, documentUri);
 
         // Construct a key to search the schema cache for an existing schema
@@ -536,7 +537,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+		const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -583,7 +584,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType &node,
         const Subschema &subschema,
-        const boost::optional<std::string> currentScope,
+		const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -600,7 +601,7 @@ private:
         typename AdapterType::Object::const_iterator itr(object.end());
 
         // Check for 'id' attribute and update current scope
-        boost::optional<std::string> updatedScope;
+		std::experimental::optional<std::string> updatedScope;
         if ((itr = object.find("id")) != object.end() &&
                 itr->second.maybeString()) {
             const std::string id = itr->second.asString();
@@ -841,7 +842,7 @@ private:
         if ((itr = object.find("required")) != object.end()) {
             if (version == kDraft3) {
                 if (parentSubschema && ownName) {
-                    boost::optional<constraints::RequiredConstraint>
+                    std::experimental::optional<constraints::RequiredConstraint>
                             constraint = makeRequiredConstraintForSelf(
                                     itr->second, *ownName);
                     if (constraint) {
@@ -877,7 +878,7 @@ private:
         }
 
         if ((itr = object.find("uniqueItems")) != object.end()) {
-            boost::optional<constraints::UniqueItemsConstraint> constraint =
+            std::experimental::optional<constraints::UniqueItemsConstraint> constraint =
                     makeUniqueItemsConstraint(itr->second);
             if (constraint) {
                 rootSchema.addConstraintToSubschema(*constraint, &subschema);
@@ -933,7 +934,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType &node,
         const Subschema &subschema,
-        const boost::optional<std::string> currentScope,
+		const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSchema,
@@ -951,7 +952,7 @@ private:
 
         // Returns a document URI if the reference points somewhere
         // other than the current document
-        const boost::optional<std::string> documentUri =
+		const std::experimental::optional<std::string> documentUri =
                 internal::json_reference::getJsonReferenceUri(jsonRef);
 
         // Extract JSON Pointer from JSON Reference
@@ -989,7 +990,7 @@ private:
 
             // TODO: Need to detect degenerate circular references
             resolveThenPopulateSchema(rootSchema, newRootNode,
-                    referencedAdapter, subschema, boost::none,
+                    referencedAdapter, subschema, std::experimental::optional<std::string>(),
                     actualJsonPointer, fetchDoc, parentSchema, ownName,
                     docCache, schemaCache);
 
@@ -1000,7 +1001,8 @@ private:
 
             // TODO: Need to detect degenerate circular references
             resolveThenPopulateSchema(rootSchema, rootNode, referencedAdapter,
-                    subschema, boost::none, actualJsonPointer, fetchDoc,
+                    subschema, std::experimental::optional<std::string>(),
+					actualJsonPointer, fetchDoc,
                     parentSchema, ownName, docCache, schemaCache);
         }
     }
@@ -1028,7 +1030,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1084,7 +1086,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+		const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1158,7 +1160,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1286,7 +1288,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType *items,
         const AdapterType *additionalItems,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &itemsPath,
         const std::string &additionalItemsPath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
@@ -1391,7 +1393,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &items,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &itemsPath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1726,7 +1728,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1766,7 +1768,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1849,7 +1851,7 @@ private:
         const AdapterType *properties,
         const AdapterType *patternProperties,
         const AdapterType *additionalProperties,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &propertiesPath,
         const std::string &patternPropertiesPath,
         const std::string &additionalPropertiesPath,
@@ -1942,7 +1944,7 @@ private:
      *          caller
      */
     template<typename AdapterType>
-    boost::optional<constraints::RequiredConstraint>
+	std::experimental::optional<constraints::RequiredConstraint>
             makeRequiredConstraintForSelf(const AdapterType &node,
                     const std::string &name)
     {
@@ -1956,7 +1958,7 @@ private:
             return constraint;
         }
 
-        return boost::none;
+        return std::experimental::optional<constraints::RequiredConstraint>();
     }
 
     /**
@@ -2010,7 +2012,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const boost::optional<std::string> currentScope,
+        const std::experimental::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -2083,7 +2085,7 @@ private:
      *          the caller, or NULL if the boolean value is false.
      */
     template<typename AdapterType>
-    boost::optional<constraints::UniqueItemsConstraint>
+    std::experimental::optional<constraints::UniqueItemsConstraint>
             makeUniqueItemsConstraint(const AdapterType &node)
     {
         if (node.isBool() || node.maybeBool()) {
@@ -2093,7 +2095,7 @@ private:
             if (node.asBool()) {
                 return constraints::UniqueItemsConstraint();
             } else {
-                return boost::none;
+                return std::experimental::optional<constraints::UniqueItemsConstraint>();
             }
         }
 

--- a/include/valijson/schema_parser.hpp
+++ b/include/valijson/schema_parser.hpp
@@ -7,11 +7,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/foreach.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/static_assert.hpp>
-#include <boost/type_traits.hpp>
-
 #include <valijson/adapters/adapter.hpp>
 #include <valijson/constraints/concrete_constraints.hpp>
 #include <valijson/internal/json_pointer.hpp>
@@ -136,7 +131,7 @@ public:
         SchemaCache schemaCache;
         try {
             resolveThenPopulateSchema(schema, node, node, schema,
-					std::experimental::optional<std::string>(), "",
+					opt::optional<std::string>(), "",
                     fetchDoc, NULL, NULL, docCache, schemaCache);
         } catch (...) {
             freeDocumentCache<AdapterType>(docCache, freeDoc);
@@ -208,9 +203,9 @@ private:
      * document URI should be used to replace the path, query and fragment
      * portions of URI provided by the resolution scope.
      */
-	static std::experimental::optional<std::string> findAbsoluteDocumentUri(
-            const std::experimental::optional<std::string> resolutionScope,
-            const std::experimental::optional<std::string> documentUri)
+	static opt::optional<std::string> findAbsoluteDocumentUri(
+            const opt::optional<std::string> resolutionScope,
+            const opt::optional<std::string> documentUri)
     {
         if (resolutionScope) {
             if (documentUri) {
@@ -226,7 +221,7 @@ private:
         } else if (documentUri && internal::uri::isUriAbsolute(*documentUri)) {
             return *documentUri;
         } else {
-            return std::experimental::optional<std::string>();
+            return opt::optional<std::string>();
         }
     }
 
@@ -263,7 +258,7 @@ private:
     /**
      * Sanitise an optional JSON Pointer, trimming trailing slashes
      */
-	std::string sanitiseJsonPointer(const std::experimental::optional<std::string> input)
+	std::string sanitiseJsonPointer(const opt::optional<std::string> input)
     {
         if (input) {
             // Trim trailing slash(es)
@@ -364,7 +359,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-		const std::experimental::optional<std::string> currentScope,
+		const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -409,7 +404,7 @@ private:
 
         // Returns a document URI if the reference points somewhere
         // other than the current document
-		const std::experimental::optional<std::string> documentUri =
+		const opt::optional<std::string> documentUri =
                 internal::json_reference::getJsonReferenceUri(jsonRef);
 
         // Extract JSON Pointer from JSON Reference, with any trailing
@@ -422,7 +417,7 @@ private:
         // scope. An absolute document URI will take precedence when
         // present, otherwise we need to resolve the URI relative to
         // the current resolution scope
-		const std::experimental::optional<std::string> actualDocumentUri =
+		const opt::optional<std::string> actualDocumentUri =
                 findAbsoluteDocumentUri(currentScope, documentUri);
 
         // Construct a key to search the schema cache for an existing schema
@@ -537,7 +532,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-		const std::experimental::optional<std::string> currentScope,
+		const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -584,7 +579,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType &node,
         const Subschema &subschema,
-		const std::experimental::optional<std::string> currentScope,
+		const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -601,7 +596,7 @@ private:
         typename AdapterType::Object::const_iterator itr(object.end());
 
         // Check for 'id' attribute and update current scope
-		std::experimental::optional<std::string> updatedScope;
+		opt::optional<std::string> updatedScope;
         if ((itr = object.find("id")) != object.end() &&
                 itr->second.maybeString()) {
             const std::string id = itr->second.asString();
@@ -842,7 +837,7 @@ private:
         if ((itr = object.find("required")) != object.end()) {
             if (version == kDraft3) {
                 if (parentSubschema && ownName) {
-                    std::experimental::optional<constraints::RequiredConstraint>
+                    opt::optional<constraints::RequiredConstraint>
                             constraint = makeRequiredConstraintForSelf(
                                     itr->second, *ownName);
                     if (constraint) {
@@ -878,7 +873,7 @@ private:
         }
 
         if ((itr = object.find("uniqueItems")) != object.end()) {
-            std::experimental::optional<constraints::UniqueItemsConstraint> constraint =
+            opt::optional<constraints::UniqueItemsConstraint> constraint =
                     makeUniqueItemsConstraint(itr->second);
             if (constraint) {
                 rootSchema.addConstraintToSubschema(*constraint, &subschema);
@@ -934,7 +929,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType &node,
         const Subschema &subschema,
-		const std::experimental::optional<std::string> currentScope,
+		const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSchema,
@@ -952,7 +947,7 @@ private:
 
         // Returns a document URI if the reference points somewhere
         // other than the current document
-		const std::experimental::optional<std::string> documentUri =
+		const opt::optional<std::string> documentUri =
                 internal::json_reference::getJsonReferenceUri(jsonRef);
 
         // Extract JSON Pointer from JSON Reference
@@ -990,7 +985,7 @@ private:
 
             // TODO: Need to detect degenerate circular references
             resolveThenPopulateSchema(rootSchema, newRootNode,
-                    referencedAdapter, subschema, std::experimental::optional<std::string>(),
+                    referencedAdapter, subschema, opt::optional<std::string>(),
                     actualJsonPointer, fetchDoc, parentSchema, ownName,
                     docCache, schemaCache);
 
@@ -1001,7 +996,7 @@ private:
 
             // TODO: Need to detect degenerate circular references
             resolveThenPopulateSchema(rootSchema, rootNode, referencedAdapter,
-                    subschema, std::experimental::optional<std::string>(),
+                    subschema, opt::optional<std::string>(),
 					actualJsonPointer, fetchDoc,
                     parentSchema, ownName, docCache, schemaCache);
         }
@@ -1030,7 +1025,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1086,7 +1081,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-		const std::experimental::optional<std::string> currentScope,
+		const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1160,7 +1155,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1288,7 +1283,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType *items,
         const AdapterType *additionalItems,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &itemsPath,
         const std::string &additionalItemsPath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
@@ -1393,7 +1388,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &items,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &itemsPath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1728,7 +1723,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1768,7 +1763,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1851,7 +1846,7 @@ private:
         const AdapterType *properties,
         const AdapterType *patternProperties,
         const AdapterType *additionalProperties,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &propertiesPath,
         const std::string &patternPropertiesPath,
         const std::string &additionalPropertiesPath,
@@ -1944,7 +1939,7 @@ private:
      *          caller
      */
     template<typename AdapterType>
-	std::experimental::optional<constraints::RequiredConstraint>
+	opt::optional<constraints::RequiredConstraint>
             makeRequiredConstraintForSelf(const AdapterType &node,
                     const std::string &name)
     {
@@ -1958,7 +1953,7 @@ private:
             return constraint;
         }
 
-        return std::experimental::optional<constraints::RequiredConstraint>();
+        return opt::optional<constraints::RequiredConstraint>();
     }
 
     /**
@@ -2012,7 +2007,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-        const std::experimental::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -2085,7 +2080,7 @@ private:
      *          the caller, or NULL if the boolean value is false.
      */
     template<typename AdapterType>
-    std::experimental::optional<constraints::UniqueItemsConstraint>
+    opt::optional<constraints::UniqueItemsConstraint>
             makeUniqueItemsConstraint(const AdapterType &node)
     {
         if (node.isBool() || node.maybeBool()) {
@@ -2095,7 +2090,7 @@ private:
             if (node.asBool()) {
                 return constraints::UniqueItemsConstraint();
             } else {
-                return std::experimental::optional<constraints::UniqueItemsConstraint>();
+                return opt::optional<constraints::UniqueItemsConstraint>();
             }
         }
 

--- a/include/valijson/schema_parser.hpp
+++ b/include/valijson/schema_parser.hpp
@@ -587,7 +587,7 @@ private:
         typename DocumentCache<AdapterType>::Type &docCache,
         SchemaCache &schemaCache)
     {
-        BOOST_STATIC_ASSERT_MSG((boost::is_convertible<AdapterType,
+        static_assert((std::is_convertible<AdapterType,
             const valijson::adapters::Adapter &>::value),
             "SchemaParser::populateSchema must be invoked with an "
             "appropriate Adapter implementation");

--- a/include/valijson/schema_parser.hpp
+++ b/include/valijson/schema_parser.hpp
@@ -131,7 +131,7 @@ public:
         SchemaCache schemaCache;
         try {
             resolveThenPopulateSchema(schema, node, node, schema,
-					opt::optional<std::string>(), "",
+                    opt::optional<std::string>(), "",
                     fetchDoc, NULL, NULL, docCache, schemaCache);
         } catch (...) {
             freeDocumentCache<AdapterType>(docCache, freeDoc);
@@ -174,7 +174,7 @@ private:
     {
         typedef typename DocumentCache<AdapterType>::Type DocCacheType;
 
-		for( const typename DocCacheType::value_type &v : docCache ) {
+        for( const typename DocCacheType::value_type &v : docCache ) {
             freeDoc(v.second);
         }
     }
@@ -203,7 +203,7 @@ private:
      * document URI should be used to replace the path, query and fragment
      * portions of URI provided by the resolution scope.
      */
-	static opt::optional<std::string> findAbsoluteDocumentUri(
+    static opt::optional<std::string> findAbsoluteDocumentUri(
             const opt::optional<std::string> resolutionScope,
             const opt::optional<std::string> documentUri)
     {
@@ -258,7 +258,7 @@ private:
     /**
      * Sanitise an optional JSON Pointer, trimming trailing slashes
      */
-	std::string sanitiseJsonPointer(const opt::optional<std::string> input)
+    std::string sanitiseJsonPointer(const opt::optional<std::string> input)
     {
         if (input) {
             // Trim trailing slash(es)
@@ -314,7 +314,7 @@ private:
             const std::vector<std::string> &keysToCreate,
             const Subschema *schema)
     {
-		for( const std::string &keyToCreate : keysToCreate ) {
+        for( const std::string &keyToCreate : keysToCreate ) {
             const SchemaCache::value_type value(keyToCreate, schema);
             if (!schemaCache.insert(value).second) {
                 throw std::logic_error(
@@ -359,7 +359,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-		const opt::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -404,7 +404,7 @@ private:
 
         // Returns a document URI if the reference points somewhere
         // other than the current document
-		const opt::optional<std::string> documentUri =
+        const opt::optional<std::string> documentUri =
                 internal::json_reference::getJsonReferenceUri(jsonRef);
 
         // Extract JSON Pointer from JSON Reference, with any trailing
@@ -417,7 +417,7 @@ private:
         // scope. An absolute document URI will take precedence when
         // present, otherwise we need to resolve the URI relative to
         // the current resolution scope
-		const opt::optional<std::string> actualDocumentUri =
+        const opt::optional<std::string> actualDocumentUri =
                 findAbsoluteDocumentUri(currentScope, documentUri);
 
         // Construct a key to search the schema cache for an existing schema
@@ -532,7 +532,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-		const opt::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -579,7 +579,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType &node,
         const Subschema &subschema,
-		const opt::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSubschema,
@@ -596,7 +596,7 @@ private:
         typename AdapterType::Object::const_iterator itr(object.end());
 
         // Check for 'id' attribute and update current scope
-		opt::optional<std::string> updatedScope;
+        opt::optional<std::string> updatedScope;
         if ((itr = object.find("id")) != object.end() &&
                 itr->second.maybeString()) {
             const std::string id = itr->second.asString();
@@ -929,7 +929,7 @@ private:
         const AdapterType &rootNode,
         const AdapterType &node,
         const Subschema &subschema,
-		const opt::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         const Subschema *parentSchema,
@@ -947,7 +947,7 @@ private:
 
         // Returns a document URI if the reference points somewhere
         // other than the current document
-		const opt::optional<std::string> documentUri =
+        const opt::optional<std::string> documentUri =
                 internal::json_reference::getJsonReferenceUri(jsonRef);
 
         // Extract JSON Pointer from JSON Reference
@@ -997,7 +997,7 @@ private:
             // TODO: Need to detect degenerate circular references
             resolveThenPopulateSchema(rootSchema, rootNode, referencedAdapter,
                     subschema, opt::optional<std::string>(),
-					actualJsonPointer, fetchDoc,
+                    actualJsonPointer, fetchDoc,
                     parentSchema, ownName, docCache, schemaCache);
         }
     }
@@ -1039,7 +1039,7 @@ private:
         constraints::AllOfConstraint constraint;
 
         int index = 0;
-		for ( const AdapterType schemaNode : node.asArray() ) {
+        for ( const AdapterType schemaNode : node.asArray() ) {
             if (schemaNode.maybeObject()) {
                 const std::string childPath = nodePath + "/" +
                         std::to_string(index);
@@ -1081,7 +1081,7 @@ private:
         Schema &rootSchema,
         const AdapterType &rootNode,
         const AdapterType &node,
-		const opt::optional<std::string> currentScope,
+        const opt::optional<std::string> currentScope,
         const std::string &nodePath,
         const typename FunctionPtrs<AdapterType>::FetchDoc fetchDoc,
         typename DocumentCache<AdapterType>::Type &docCache,
@@ -1095,7 +1095,7 @@ private:
         constraints::AnyOfConstraint constraint;
 
         int index = 0;
-		for ( const AdapterType schemaNode : node.asArray() ) {
+        for ( const AdapterType schemaNode : node.asArray() ) {
             if (schemaNode.maybeObject()) {
                 const std::string childPath = nodePath + "/" +
                         std::to_string(index);
@@ -1168,7 +1168,7 @@ private:
         constraints::DependenciesConstraint dependenciesConstraint;
 
         // Process each of the dependency mappings defined by the object
-		for ( const typename AdapterType::ObjectMember member : node.asObject() ) {
+        for ( const typename AdapterType::ObjectMember member : node.asObject() ) {
 
             // First, we attempt to parse the value of the dependency mapping
             // as an array of strings. If the Adapter type does not support
@@ -1180,7 +1180,7 @@ private:
             if (member.second.maybeArray()) {
                 // Parse an array of dependency names
                 std::vector<std::string> dependentPropertyNames;
-				for( const AdapterType dependencyName : member.second.asArray() ) {
+                for( const AdapterType dependencyName : member.second.asArray() ) {
                     if (dependencyName.maybeString()) {
                         dependentPropertyNames.push_back(dependencyName.getString());
                     } else {
@@ -1237,7 +1237,7 @@ private:
     {
         // Make a copy of each value in the enum array
         constraints::EnumConstraint constraint;
-		for( const AdapterType value : node.getArray() ) {
+        for( const AdapterType value : node.getArray() ) {
             constraint.addValue(value);
         }
 
@@ -1335,7 +1335,7 @@ private:
                 // validate the values at the corresponding indexes in a target
                 // array.
                 int index = 0;
-				for( const AdapterType v : items->getArray() ) {
+                for( const AdapterType v : items->getArray() ) {
                     const std::string childPath = itemsPath + "/" +
                             std::to_string(index);
                     const Subschema *subschema = makeOrReuseSchema<AdapterType>(
@@ -1772,7 +1772,7 @@ private:
         constraints::OneOfConstraint constraint;
 
         int index = 0;
-		for ( const AdapterType schemaNode : node.getArray() ) {
+        for ( const AdapterType schemaNode : node.getArray() ) {
             const std::string childPath = nodePath + "/" +
                     std::to_string(index);
             const Subschema *subschema = makeOrReuseSchema<AdapterType>(
@@ -1861,7 +1861,7 @@ private:
 
         // Create subschemas for 'properties' constraint
         if (properties) {
-			for( const Member m : properties->getObject() ) {
+            for( const Member m : properties->getObject() ) {
                 const std::string &property = m.first;
                 const std::string childPath = propertiesPath + "/" + property;
                 const Subschema *subschema = makeOrReuseSchema<AdapterType>(
@@ -1874,7 +1874,7 @@ private:
 
         // Create subschemas for 'patternProperties' constraint
         if (patternProperties) {
-			for( const Member m : patternProperties->getObject() ) {
+            for( const Member m : patternProperties->getObject() ) {
                 const std::string &pattern = m.first;
                 const std::string childPath = patternPropertiesPath + "/" +
                         pattern;
@@ -1939,7 +1939,7 @@ private:
      *          caller
      */
     template<typename AdapterType>
-	opt::optional<constraints::RequiredConstraint>
+    opt::optional<constraints::RequiredConstraint>
             makeRequiredConstraintForSelf(const AdapterType &node,
                     const std::string &name)
     {
@@ -1973,7 +1973,7 @@ private:
     {
         constraints::RequiredConstraint constraint;
 
-		for( const AdapterType v : node.getArray() ) {
+        for( const AdapterType v : node.getArray() ) {
             if (!v.isString()) {
                 throw std::runtime_error("Expected required property name to "
                         "be a string value");
@@ -2030,7 +2030,7 @@ private:
 
         } else if (node.isArray()) {
             int index = 0;
-			for( const AdapterType v : node.getArray() ) {
+            for( const AdapterType v : node.getArray() ) {
                 if (v.isString()) {
                     const TypeConstraint::JsonType type =
                             TypeConstraint::jsonTypeFromString(v.getString());

--- a/include/valijson/schema_parser.hpp
+++ b/include/valijson/schema_parser.hpp
@@ -1042,7 +1042,7 @@ private:
 		for ( const AdapterType schemaNode : node.asArray() ) {
             if (schemaNode.maybeObject()) {
                 const std::string childPath = nodePath + "/" +
-                        boost::lexical_cast<std::string>(index);
+                        std::to_string(index);
                 const Subschema *subschema = makeOrReuseSchema<AdapterType>(
                         rootSchema, rootNode, schemaNode, currentScope,
                         childPath, fetchDoc, NULL, NULL, docCache, schemaCache);
@@ -1098,7 +1098,7 @@ private:
 		for ( const AdapterType schemaNode : node.asArray() ) {
             if (schemaNode.maybeObject()) {
                 const std::string childPath = nodePath + "/" +
-                        boost::lexical_cast<std::string>(index);
+                        std::to_string(index);
                 const Subschema *subschema = makeOrReuseSchema<AdapterType>(
                         rootSchema, rootNode, schemaNode, currentScope,
                         childPath, fetchDoc, NULL, NULL, docCache, schemaCache);
@@ -1337,7 +1337,7 @@ private:
                 int index = 0;
 				for( const AdapterType v : items->getArray() ) {
                     const std::string childPath = itemsPath + "/" +
-                            boost::lexical_cast<std::string>(index);
+                            std::to_string(index);
                     const Subschema *subschema = makeOrReuseSchema<AdapterType>(
                             rootSchema, rootNode, v, currentScope, childPath,
                             fetchDoc, NULL, NULL, docCache, schemaCache);
@@ -1774,7 +1774,7 @@ private:
         int index = 0;
 		for ( const AdapterType schemaNode : node.getArray() ) {
             const std::string childPath = nodePath + "/" +
-                    boost::lexical_cast<std::string>(index);
+                    std::to_string(index);
             const Subschema *subschema = makeOrReuseSchema<AdapterType>(
                 rootSchema, rootNode, schemaNode, currentScope, childPath,
                 fetchDoc, NULL, NULL, docCache, schemaCache);
@@ -2045,7 +2045,7 @@ private:
 
                 } else if (v.isObject() && version == kDraft3) {
                     const std::string childPath = nodePath + "/" +
-                            boost::lexical_cast<std::string>(index);
+                            std::to_string(index);
                     const Subschema *subschema = makeOrReuseSchema<AdapterType>(
                             rootSchema, rootNode, v, currentScope, childPath,
                             fetchDoc, NULL, NULL, docCache, schemaCache);

--- a/include/valijson/subschema.hpp
+++ b/include/valijson/subschema.hpp
@@ -4,8 +4,16 @@
 
 #include <vector>
 
-#include <boost/function.hpp>
 #include <memory>
+
+// This should be removed once C++17 is widely available
+#if __has_include(<optional>)
+#  include <optional>
+namespace opt = std;
+#else
+#  include <compat/optional.hpp>
+namespace opt = std::experimental;
+#endif
 
 #include <valijson/constraints/constraint.hpp>
 
@@ -35,7 +43,7 @@ public:
 
     /// Typedef for a function that can be applied to each of the Constraint
     /// instances owned by a Schema.
-    typedef boost::function<bool (const Constraint &)> ApplyFunction;
+    typedef std::function<bool (const Constraint &)> ApplyFunction;
 
     /**
      * @brief  Construct a new Subschema object
@@ -196,7 +204,7 @@ public:
      */
     bool hasDescription() const
     {
-        return description != boost::none;
+        return static_cast<bool>(description);
     }
 
     /**
@@ -206,7 +214,7 @@ public:
      */
     bool hasId() const
     {
-        return id != boost::none;
+        return static_cast<bool>(id);
     }
 
     /**
@@ -216,7 +224,7 @@ public:
      */
     bool hasTitle() const
     {
-        return title != boost::none;
+        return static_cast<bool>(title);
     }
 
     /**
@@ -272,13 +280,13 @@ private:
     std::vector<const Constraint *> constraints;
 
     /// Schema description (optional)
-    boost::optional<std::string> description;
+    opt::optional<std::string> description;
 
     /// Id to apply when resolving the schema URI
-    boost::optional<std::string> id;
+    opt::optional<std::string> id;
 
     /// Title string associated with the schema (optional)
-    boost::optional<std::string> title;
+    opt::optional<std::string> title;
 };
 
 } // namespace valijson

--- a/include/valijson/subschema.hpp
+++ b/include/valijson/subschema.hpp
@@ -4,9 +4,7 @@
 
 #include <vector>
 
-#include <boost/foreach.hpp>
 #include <boost/function.hpp>
-#include <boost/optional.hpp>
 #include <memory>
 
 #include <valijson/constraints/constraint.hpp>
@@ -115,7 +113,7 @@ public:
     bool apply(ApplyFunction &applyFunction) const
     {
         bool allTrue = true;
-        BOOST_FOREACH( const Constraint *constraint, constraints ) {
+		for( const Constraint *constraint : constraints ) {
             allTrue = allTrue && applyFunction(*constraint);
         }
 
@@ -134,7 +132,7 @@ public:
      */
     bool applyStrict(ApplyFunction &applyFunction) const
     {
-        BOOST_FOREACH( const Constraint *constraint, constraints ) {
+		for( const Constraint *constraint : constraints ) {
             if (!applyFunction(*constraint)) {
                 return false;
             }

--- a/include/valijson/subschema.hpp
+++ b/include/valijson/subschema.hpp
@@ -121,7 +121,7 @@ public:
     bool apply(ApplyFunction &applyFunction) const
     {
         bool allTrue = true;
-		for( const Constraint *constraint : constraints ) {
+        for( const Constraint *constraint : constraints ) {
             allTrue = allTrue && applyFunction(*constraint);
         }
 
@@ -140,7 +140,7 @@ public:
      */
     bool applyStrict(ApplyFunction &applyFunction) const
     {
-		for( const Constraint *constraint : constraints ) {
+        for( const Constraint *constraint : constraints ) {
             if (!applyFunction(*constraint)) {
                 return false;
             }

--- a/include/valijson/utils/utf8_utils.hpp
+++ b/include/valijson/utils/utf8_utils.hpp
@@ -50,7 +50,7 @@ inline uint64_t u8_strlen(const char *s)
         if (i == maxLength) {
             throw std::runtime_error(
                     "String exceeded maximum size of " +
-                    boost::lexical_cast<std::string>(maxLength) + " bytes.");
+                    std::to_string(maxLength) + " bytes.");
         }
         count++;
     }

--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -3,11 +3,8 @@
 #define __VALIJSON_VALIDATION_VISITOR_HPP
 
 #include <cmath>
-
+#include <string>
 #include <regex>
-
-#include <boost/lexical_cast.hpp>
-#include <boost/variant/get.hpp>
 
 #include <valijson/constraints/concrete_constraints.hpp>
 #include <valijson/constraints/constraint_visitor.hpp>
@@ -71,7 +68,7 @@ public:
         // Wrap the validationCallback() function below so that it will be
         // passed a reference to a constraint (_1), and a reference to the
         // visitor (*this).
-        Subschema::ApplyFunction fn(boost::bind(validationCallback, _1, *this));
+		Subschema::ApplyFunction fn(std::bind(validationCallback, std::placeholders::_1, *this));
 
         // Perform validation against each constraint defined in the schema
         if (results == NULL) {
@@ -309,7 +306,7 @@ public:
                     // Update context for current array item
                     std::vector<std::string> newContext = context;
                     newContext.push_back("[" +
-                            boost::lexical_cast<std::string>(index) + "]");
+                            std::to_string(index) + "]");
 
                     ValidationVisitor<AdapterType> validator(*itr, newContext,
                             strictTypes, results);
@@ -318,7 +315,7 @@ public:
                         if (results) {
                             results->pushError(context,
                                     "Failed to validate item #" +
-                                    boost::lexical_cast<std::string>(index) +
+                                    std::to_string(index) +
                                     " against additional items schema.");
                             validated = false;
                         } else {
@@ -331,7 +328,7 @@ public:
 
             } else if (results) {
                 results->pushError(context, "Cannot validate item #" +
-                    boost::lexical_cast<std::string>(numValidated) + " or "
+                    std::to_string(numValidated) + " or "
                     "greater using 'items' constraint or 'additionalItems' "
                     "constraint.");
                 validated = false;
@@ -364,7 +361,7 @@ public:
             if (target.asDouble() >= maximum) {
                 if (results) {
                     results->pushError(context, "Expected number less than " +
-                            boost::lexical_cast<std::string>(maximum));
+                            std::to_string(maximum));
                 }
 
                 return false;
@@ -374,7 +371,7 @@ public:
             if (results) {
                 results->pushError(context,
                         "Expected number less than or equal to " +
-                        boost::lexical_cast<std::string>(maximum));
+                        std::to_string(maximum));
             }
 
             return false;
@@ -403,7 +400,7 @@ public:
 
         if (results) {
             results->pushError(context, "Array should contain no more than " +
-                    boost::lexical_cast<std::string>(maxItems) + " elements.");
+                    std::to_string(maxItems) + " elements.");
         }
 
         return false;
@@ -432,7 +429,7 @@ public:
         if (results) {
             results->pushError(context,
                     "String should be no more than " +
-                    boost::lexical_cast<std::string>(maxLength) +
+                    std::to_string(maxLength) +
                     " characters in length.");
         }
 
@@ -460,7 +457,7 @@ public:
 
         if (results) {
             results->pushError(context, "Object should have no more than " +
-                    boost::lexical_cast<std::string>(maxProperties) +
+                    std::to_string(maxProperties) +
                     " properties.");
         }
 
@@ -488,7 +485,7 @@ public:
                 if (results) {
                     results->pushError(context,
                         "Expected number greater than " +
-                        boost::lexical_cast<std::string>(minimum));
+                        std::to_string(minimum));
                 }
 
                 return false;
@@ -497,7 +494,7 @@ public:
             if (results) {
                 results->pushError(context,
                         "Expected number greater than or equal to " +
-                        boost::lexical_cast<std::string>(minimum));
+                        std::to_string(minimum));
             }
 
             return false;
@@ -526,7 +523,7 @@ public:
 
         if (results) {
             results->pushError(context, "Array should contain no fewer than " +
-                boost::lexical_cast<std::string>(minItems) + " elements.");
+                std::to_string(minItems) + " elements.");
         }
 
         return false;
@@ -555,7 +552,7 @@ public:
         if (results) {
             results->pushError(context,
                     "String should be no fewer than " +
-                    boost::lexical_cast<std::string>(minLength) +
+                    std::to_string(minLength) +
                     " characters in length.");
         }
 
@@ -583,7 +580,7 @@ public:
 
         if (results) {
             results->pushError(context, "Object should have no fewer than " +
-                    boost::lexical_cast<std::string>(minProperties) +
+                    std::to_string(minProperties) +
                     " properties.");
         }
 
@@ -607,7 +604,7 @@ public:
                 if (results) {
                     results->pushError(context, "Value could not be converted "
                         "to a number to check if it is a multiple of " +
-                        boost::lexical_cast<std::string>(divisor));
+                        std::to_string(divisor));
                 }
                 return false;
             }
@@ -617,7 +614,7 @@ public:
                 if (results) {
                     results->pushError(context, "Value could not be converted "
                         "to a number to check if it is a multiple of " +
-                        boost::lexical_cast<std::string>(divisor));
+                        std::to_string(divisor));
                 }
                 return false;
             }
@@ -635,7 +632,7 @@ public:
         if (fabs(r) > std::numeric_limits<double>::epsilon()) {
             if (results) {
                 results->pushError(context, "Value should be a multiple of " +
-                    boost::lexical_cast<std::string>(divisor));
+                    std::to_string(divisor));
             }
             return false;
         }
@@ -684,7 +681,7 @@ public:
         if (i % divisor != 0) {
             if (results) {
                 results->pushError(context, "Value should be a multiple of " +
-                    boost::lexical_cast<std::string>(divisor));
+                    std::to_string(divisor));
             }
             return false;
         }
@@ -963,7 +960,7 @@ public:
             // Update context for current array item
             std::vector<std::string> newContext = context;
             newContext.push_back("[" +
-                    boost::lexical_cast<std::string>(index) + "]");
+                    std::to_string(index) + "]");
 
             // Create a validator for the current array item
             ValidationVisitor<AdapterType> validationVisitor(item,
@@ -974,7 +971,7 @@ public:
                 if (results) {
                     results->pushError(context,
                             "Failed to validate item #" +
-                            boost::lexical_cast<std::string>(index) +
+                            std::to_string(index) +
                             " in array.");
                     validated = false;
                 } else {
@@ -1062,8 +1059,8 @@ public:
                 if (outerItr->equalTo(*innerItr, true)) {
                     if (results) {
                         results->pushError(context, "Elements at indexes #" +
-                            boost::lexical_cast<std::string>(outerIndex) + " and #" +
-                            boost::lexical_cast<std::string>(innerIndex) + " violate uniqueness constraint.");
+                            std::to_string(outerIndex) + " and #" +
+                            std::to_string(innerIndex) + " violate uniqueness constraint.");
                         validated = false;
                     } else {
                         return false;
@@ -1260,7 +1257,7 @@ private:
             // Update context
             std::vector<std::string> newContext = context;
             newContext.push_back(
-                    "[" + boost::lexical_cast<std::string>(index) + "]");
+                    "[" + std::to_string(index) + "]");
 
             // Find array item
             typename AdapterType::Array::const_iterator itr = arr.begin();
@@ -1283,7 +1280,7 @@ private:
             if (results) {
                 results->pushError(newContext,
                     "Failed to validate item #" +
-                    boost::lexical_cast<std::string>(index) +
+                    std::to_string(index) +
                     " against corresponding item schema.");
             }
 
@@ -1647,7 +1644,7 @@ private:
             if (results) {
                 results->pushError(context,
                         "Failed to validate against child schema #" +
-                        boost::lexical_cast<std::string>(index) + ".");
+								   std::to_string(index) + ".");
             }
 
             return continueOnFailure;

--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -4,8 +4,9 @@
 
 #include <cmath>
 
+#include <regex>
+
 #include <boost/lexical_cast.hpp>
-#include <boost/regex.hpp>
 #include <boost/variant/get.hpp>
 
 #include <valijson/constraints/concrete_constraints.hpp>
@@ -777,11 +778,10 @@ public:
             return true;
         }
 
-        const boost::regex patternRegex(
-                constraint.getPattern<std::string::allocator_type>(),
-                boost::regex::perl);
+		const std::regex patternRegex(
+                constraint.getPattern<std::string::allocator_type>());
 
-        if (!boost::regex_search(target.asString(), patternRegex)) {
+        if (!std::regex_search(target.asString(), patternRegex)) {
             if (results) {
                 results->pushError(context,
                         "Failed to match regex specified by 'pattern' "
@@ -1405,17 +1405,17 @@ private:
             const std::string patternPropertyStr(patternProperty.c_str());
 
             // It would be nice to store pre-allocated regex objects in the
-            // PropertiesConstraint, but boost::regex does not currently support
-            // custom allocators. This isn't an issue here, because Valijson's
+            // PropertiesConstraint. does std::regex currently support
+            // custom allocators? Anyway, this isn't an issue here, because Valijson's
             // JSON Scheme validator does not yet support custom allocators.
-            const boost::regex r(patternPropertyStr, boost::regex::perl);
+            const std::regex r(patternPropertyStr);
 
             bool matchFound = false;
 
             // Recursively validate all matching properties
             typedef const typename AdapterType::ObjectMember ObjectMember;
 			for( const ObjectMember m : object ) {
-                if (boost::regex_search(m.first, r)) {
+                if (std::regex_search(m.first, r)) {
                     matchFound = true;
                     if (propertiesMatched) {
                         propertiesMatched->insert(m.first);

--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -878,7 +878,7 @@ public:
             return validated;
         }
 
-        BOOST_FOREACH( const typename AdapterType::ObjectMember m, object ) {
+		for( const typename AdapterType::ObjectMember m : object ) {
             if (propertiesMatched.find(m.first) == propertiesMatched.end()) {
                 // Update context
                 std::vector<std::string> newContext = context;
@@ -959,7 +959,7 @@ public:
         bool validated = true;
 
         unsigned int index = 0;
-        BOOST_FOREACH( const AdapterType &item, target.getArray() ) {
+		for( const AdapterType &item : target.getArray() ) {
             // Update context for current array item
             std::vector<std::string> newContext = context;
             newContext.push_back("[" +
@@ -1202,7 +1202,7 @@ private:
             }
 
             typedef typename ContainerType::value_type ValueType;
-            BOOST_FOREACH( const ValueType &dependencyName, dependencyNames ) {
+			for( const ValueType &dependencyName : dependencyNames ) {
                 const std::string dependencyNameKey(dependencyName.c_str());
                 if (object.find(dependencyNameKey) == object.end()) {
                     if (validated) {
@@ -1414,7 +1414,7 @@ private:
 
             // Recursively validate all matching properties
             typedef const typename AdapterType::ObjectMember ObjectMember;
-            BOOST_FOREACH( const ObjectMember m, object ) {
+			for( const ObjectMember m : object ) {
                 if (boost::regex_search(m.first, r)) {
                     matchFound = true;
                     if (propertiesMatched) {

--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -68,7 +68,7 @@ public:
         // Wrap the validationCallback() function below so that it will be
         // passed a reference to a constraint (_1), and a reference to the
         // visitor (*this).
-		Subschema::ApplyFunction fn(std::bind(validationCallback, std::placeholders::_1, *this));
+        Subschema::ApplyFunction fn(std::bind(validationCallback, std::placeholders::_1, *this));
 
         // Perform validation against each constraint defined in the schema
         if (results == NULL) {
@@ -775,7 +775,7 @@ public:
             return true;
         }
 
-		const std::regex patternRegex(
+        const std::regex patternRegex(
                 constraint.getPattern<std::string::allocator_type>());
 
         if (!std::regex_search(target.asString(), patternRegex)) {
@@ -875,7 +875,7 @@ public:
             return validated;
         }
 
-		for( const typename AdapterType::ObjectMember m : object ) {
+        for( const typename AdapterType::ObjectMember m : object ) {
             if (propertiesMatched.find(m.first) == propertiesMatched.end()) {
                 // Update context
                 std::vector<std::string> newContext = context;
@@ -956,7 +956,7 @@ public:
         bool validated = true;
 
         unsigned int index = 0;
-		for( const AdapterType &item : target.getArray() ) {
+        for( const AdapterType &item : target.getArray() ) {
             // Update context for current array item
             std::vector<std::string> newContext = context;
             newContext.push_back("[" +
@@ -1199,7 +1199,7 @@ private:
             }
 
             typedef typename ContainerType::value_type ValueType;
-			for( const ValueType &dependencyName : dependencyNames ) {
+            for( const ValueType &dependencyName : dependencyNames ) {
                 const std::string dependencyNameKey(dependencyName.c_str());
                 if (object.find(dependencyNameKey) == object.end()) {
                     if (validated) {
@@ -1411,7 +1411,7 @@ private:
 
             // Recursively validate all matching properties
             typedef const typename AdapterType::ObjectMember ObjectMember;
-			for( const ObjectMember m : object ) {
+            for( const ObjectMember m : object ) {
                 if (std::regex_search(m.first, r)) {
                     matchFound = true;
                     if (propertiesMatched) {
@@ -1644,7 +1644,7 @@ private:
             if (results) {
                 results->pushError(context,
                         "Failed to validate against child schema #" +
-								   std::to_string(index) + ".");
+                                   std::to_string(index) + ".");
             }
 
             return continueOnFailure;

--- a/include/valijson/validator.hpp
+++ b/include/valijson/validator.hpp
@@ -2,9 +2,6 @@
 #ifndef __VALIJSON_VALIDATOR_HPP
 #define __VALIJSON_VALIDATOR_HPP
 
-#include <boost/bind.hpp>
-#include <boost/scoped_ptr.hpp>
-
 #include <valijson/schema.hpp>
 #include <valijson/validation_visitor.hpp>
 

--- a/tests/test_adapter_comparison.cpp
+++ b/tests/test_adapter_comparison.cpp
@@ -1,8 +1,5 @@
 #include <picojson.h>
 
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include <gtest/gtest.h>
 
 #include <valijson/adapters/jsoncpp_adapter.hpp>

--- a/tests/test_fetch_document_callback.cpp
+++ b/tests/test_fetch_document_callback.cpp
@@ -1,4 +1,3 @@
-#include <boost/make_shared.hpp>
 
 #include <gtest/gtest.h>
 

--- a/tests/test_json11_adapter.cpp
+++ b/tests/test_json11_adapter.cpp
@@ -35,7 +35,7 @@ TEST_F(TestJson11Adapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::Json11Adapter value : adapter.getArray() ) {
+    for( const valijson::adapters::Json11Adapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -72,7 +72,7 @@ TEST_F(TestJson11Adapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::Json11Adapter::ObjectMember member : adapter.getObject() ) {
+    for( const valijson::adapters::Json11Adapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
         EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );

--- a/tests/test_json11_adapter.cpp
+++ b/tests/test_json11_adapter.cpp
@@ -1,8 +1,5 @@
 #ifdef VALIJSON_BUILD_CXX11_ADAPTERS
 
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include <gtest/gtest.h>
 
 #include <valijson/adapters/json11_adapter.hpp>
@@ -38,7 +35,7 @@ TEST_F(TestJson11Adapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::Json11Adapter value, adapter.getArray() ) {
+	for( const valijson::adapters::Json11Adapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -56,7 +53,7 @@ TEST_F(TestJson11Adapter, BasicObjectIteration)
     // strings their corresponding numeric values
     json11::Json::object object;
     for (unsigned int i = 0; i < numElements; i++) {
-        std::string name(boost::lexical_cast<std::string>(i));
+        std::string name(std::to_string(i));
         object[name] = json11::Json(static_cast<double>(i));
     }
     json11::Json document(object);
@@ -75,9 +72,9 @@ TEST_F(TestJson11Adapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::Json11Adapter::ObjectMember member, adapter.getObject() ) {
+	for( const valijson::adapters::Json11Adapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
-        EXPECT_EQ( boost::lexical_cast<std::string>(expectedValue), member.first );
+        EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );
         expectedValue++;
     }

--- a/tests/test_json_pointer.cpp
+++ b/tests/test_json_pointer.cpp
@@ -1,5 +1,3 @@
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <gtest/gtest.h>
 
@@ -36,43 +34,43 @@ struct JsonPointerTestCase
     rapidjson::Value *expectedValue;
 };
 
-std::vector<boost::shared_ptr<JsonPointerTestCase> >
+std::vector<std::shared_ptr<JsonPointerTestCase> >
         testCasesForSingleLevelObjectPointers(
                 RapidJsonCrtAllocator &allocator)
 {
-    typedef boost::shared_ptr<JsonPointerTestCase> TestCase;
+    typedef std::shared_ptr<JsonPointerTestCase> TestCase;
 
     std::vector<TestCase> testCases;
 
-    TestCase testCase = boost::make_shared<JsonPointerTestCase>(
+    TestCase testCase = std::make_shared<JsonPointerTestCase>(
             "Resolving '#' should cause an exception to be thrown");
     testCase->value.SetNull();
     testCase->jsonPointer = "#";
     testCase->expectedValue = NULL;
     testCases.push_back(testCase);
 
-    testCase = boost::make_shared<JsonPointerTestCase>(
+    testCase = std::make_shared<JsonPointerTestCase>(
             "Resolving an empty string should return the root node");
     testCase->value.SetNull();
     testCase->jsonPointer = "";
     testCase->expectedValue = &testCase->value;
     testCases.push_back(testCase);
 
-    testCase = boost::make_shared<JsonPointerTestCase>(
+    testCase = std::make_shared<JsonPointerTestCase>(
             "Resolving '/' should return the root node");
     testCase->value.SetNull();
     testCase->jsonPointer = "/";
     testCase->expectedValue = &testCase->value;
     testCases.push_back(testCase);
 
-    testCase = boost::make_shared<JsonPointerTestCase>(
+    testCase = std::make_shared<JsonPointerTestCase>(
             "Resolving '//' should return the root node");
     testCase->value.SetNull();
     testCase->jsonPointer = "//";
     testCase->expectedValue = &testCase->value;
     testCases.push_back(testCase);
 
-    testCase = boost::make_shared<JsonPointerTestCase>(
+    testCase = std::make_shared<JsonPointerTestCase>(
             "Resolve '/test' in object containing one member named 'test'");
     testCase->value.SetObject();
     testCase->value.AddMember("test", "test", allocator);
@@ -80,7 +78,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
     testCase->expectedValue = &testCase->value.FindMember("test")->value;
     testCases.push_back(testCase);
 
-    testCase = boost::make_shared<JsonPointerTestCase>(
+    testCase = std::make_shared<JsonPointerTestCase>(
             "Resolve '/test/' in object containing one member named 'test'");
     testCase->value.SetObject();
     testCase->value.AddMember("test", "test", allocator);
@@ -88,7 +86,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
     testCase->expectedValue = &testCase->value.FindMember("test")->value;
     testCases.push_back(testCase);
 
-    testCase = boost::make_shared<JsonPointerTestCase>(
+    testCase = std::make_shared<JsonPointerTestCase>(
             "Resolve '//test//' in object containing one member named 'test'");
     testCase->value.SetObject();
     testCase->value.AddMember("test", "test", allocator);
@@ -96,7 +94,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
     testCase->expectedValue = &testCase->value.FindMember("test")->value;
     testCases.push_back(testCase);
 
-    testCase = boost::make_shared<JsonPointerTestCase>(
+    testCase = std::make_shared<JsonPointerTestCase>(
             "Resolve '/missing' in object containing one member name 'test'");
     testCase->value.SetObject();
     testCase->value.AddMember("test", "test", allocator);
@@ -111,7 +109,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         testArray.PushBack("test1", allocator);
         testArray.PushBack("test2", allocator);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolve '/test/0' in object containing one member containing "
                 "an array with 3 elements");
         testCase->value.SetObject();
@@ -128,7 +126,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         testArray.PushBack("test1", allocator);
         testArray.PushBack("test2", allocator);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolve '/test/1' in object containing one member containing "
                 "an array with 3 elements");
         testCase->value.SetObject();
@@ -145,7 +143,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         testArray.PushBack("test1", allocator);
         testArray.PushBack("test2", allocator);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolve '/test/2' in object containing one member containing "
                 "an array with 3 elements");
         testCase->value.SetObject();
@@ -162,7 +160,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         testArray.PushBack("test1", allocator);
         testArray.PushBack("test2", allocator);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolving '/test/3' in object containing one member containing "
                 "an array with 3 elements should throw an exception");
         testCase->value.SetObject();
@@ -193,7 +191,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         testArray.PushBack("test1", allocator);
         testArray.PushBack("test2", allocator);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolving '/test/-' in object containing one member containing "
                 "an array with 3 elements should throw an exception");
         testCase->value.SetNull();
@@ -221,7 +219,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         rapidjson::Value value;
         value.SetDouble(10.);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolving '/hello~1world' in object containing one member named "
                 "'hello/world' should return the associated value");
         testCase->value.SetObject();
@@ -235,7 +233,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         rapidjson::Value value;
         value.SetDouble(10.);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolving '/hello~0world' in object containing one member named "
                 "'hello~world' should return the associated value");
         testCase->value.SetObject();
@@ -249,7 +247,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
         rapidjson::Value value;
         value.SetDouble(10.);
 
-        testCase = boost::make_shared<JsonPointerTestCase>(
+        testCase = std::make_shared<JsonPointerTestCase>(
                 "Resolving '/hello~01world' in object containing one member named "
                 "'hello~1world' should return the associated value");
         testCase->value.SetObject();
@@ -264,7 +262,7 @@ std::vector<boost::shared_ptr<JsonPointerTestCase> >
 
 TEST_F(TestJsonPointer, JsonPointerTestCases)
 {
-    typedef std::vector<boost::shared_ptr<JsonPointerTestCase> > TestCases;
+    typedef std::vector<std::shared_ptr<JsonPointerTestCase> > TestCases;
 
     // Ensure memory used for test cases is freed when test function completes
     rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> allocator;

--- a/tests/test_jsoncpp_adapter.cpp
+++ b/tests/test_jsoncpp_adapter.cpp
@@ -1,5 +1,3 @@
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <gtest/gtest.h>
 
@@ -34,7 +32,7 @@ TEST_F(TestJsonCppAdapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::JsonCppAdapter value, adapter.getArray() ) {
+	for( const valijson::adapters::JsonCppAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getNumber() );
         expectedValue++;
@@ -52,7 +50,7 @@ TEST_F(TestJsonCppAdapter, BasicObjectIteration)
     // strings their corresponding numeric values
     Json::Value document(Json::objectValue);
     for (unsigned int i = 0; i < numElements; i++) {
-        std::string name(boost::lexical_cast<std::string>(i));
+        std::string name(std::to_string(i));
         document[name] = Json::Value(double(i));
     }
 
@@ -70,9 +68,9 @@ TEST_F(TestJsonCppAdapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::JsonCppAdapter::ObjectMember member, adapter.getObject() ) {
+	for( const valijson::adapters::JsonCppAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
-        EXPECT_EQ( boost::lexical_cast<std::string>(expectedValue), member.first );
+        EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );
         expectedValue++;
     }

--- a/tests/test_nlohmann_json_adapter.cpp
+++ b/tests/test_nlohmann_json_adapter.cpp
@@ -34,7 +34,7 @@ TEST_F(TestNlohmannJsonAdapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::NlohmannJsonAdapter value : adapter.getArray() ) {
+    for( const valijson::adapters::NlohmannJsonAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -69,7 +69,7 @@ TEST_F(TestNlohmannJsonAdapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::NlohmannJsonAdapter::ObjectMember member : adapter.getObject() ) {
+    for( const valijson::adapters::NlohmannJsonAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
         EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );

--- a/tests/test_nlohmann_json_adapter.cpp
+++ b/tests/test_nlohmann_json_adapter.cpp
@@ -1,8 +1,5 @@
 #ifdef VALIJSON_BUILD_CXX11_ADAPTERS
 
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include <gtest/gtest.h>
 
 #include <valijson/adapters/nlohmann_json_adapter.hpp>
@@ -37,7 +34,7 @@ TEST_F(TestNlohmannJsonAdapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::NlohmannJsonAdapter value, adapter.getArray() ) {
+	for( const valijson::adapters::NlohmannJsonAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -55,7 +52,7 @@ TEST_F(TestNlohmannJsonAdapter, BasicObjectIteration)
     // strings their corresponding numeric values
     nlohmann::json document;
     for (uint32_t i = 0; i < numElements; i++) {
-        document[boost::lexical_cast<std::string>(i)] = static_cast<double>(i);
+        document[std::to_string(i)] = static_cast<double>(i);
     }
 
     // Ensure that wrapping the document preserves the object and does not
@@ -72,9 +69,9 @@ TEST_F(TestNlohmannJsonAdapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::NlohmannJsonAdapter::ObjectMember member, adapter.getObject() ) {
+	for( const valijson::adapters::NlohmannJsonAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
-        EXPECT_EQ( boost::lexical_cast<std::string>(expectedValue), member.first );
+        EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );
         expectedValue++;
     }

--- a/tests/test_picojson_adapter.cpp
+++ b/tests/test_picojson_adapter.cpp
@@ -35,7 +35,7 @@ TEST_F(TestPicoJsonAdapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::PicoJsonAdapter value : adapter.getArray() ) {
+    for( const valijson::adapters::PicoJsonAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -72,7 +72,7 @@ TEST_F(TestPicoJsonAdapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::PicoJsonAdapter::ObjectMember member : adapter.getObject() ) {
+    for( const valijson::adapters::PicoJsonAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
         EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );

--- a/tests/test_picojson_adapter.cpp
+++ b/tests/test_picojson_adapter.cpp
@@ -1,5 +1,4 @@
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -36,7 +35,7 @@ TEST_F(TestPicoJsonAdapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::PicoJsonAdapter value, adapter.getArray() ) {
+	for( const valijson::adapters::PicoJsonAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -54,7 +53,7 @@ TEST_F(TestPicoJsonAdapter, BasicObjectIteration)
     // strings their corresponding numeric values
     picojson::object object;
     for (unsigned int i = 0; i < numElements; i++) {
-        std::string name(boost::lexical_cast<std::string>(i));
+        std::string name(std::to_string(i));
         object[name] = picojson::value(static_cast<double>(i));
     }
     picojson::value document(object);
@@ -73,9 +72,9 @@ TEST_F(TestPicoJsonAdapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::PicoJsonAdapter::ObjectMember member, adapter.getObject() ) {
+	for( const valijson::adapters::PicoJsonAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
-        EXPECT_EQ( boost::lexical_cast<std::string>(expectedValue), member.first );
+        EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );
         expectedValue++;
     }

--- a/tests/test_property_tree_adapter.cpp
+++ b/tests/test_property_tree_adapter.cpp
@@ -1,5 +1,3 @@
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <gtest/gtest.h>
 
@@ -19,7 +17,7 @@ TEST_F(TestPropertyTreeAdapter, BasicArrayIteration)
     boost::property_tree::ptree document;
     for (unsigned int i = 0; i < numElements; i++) {
         document.push_back(std::make_pair(std::string(),
-            boost::property_tree::ptree(boost::lexical_cast<std::string>(i))));
+            boost::property_tree::ptree(std::to_string(i))));
     }
 
     // Ensure that wrapping the document preserves the array and does not allow
@@ -36,7 +34,7 @@ TEST_F(TestPropertyTreeAdapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::PropertyTreeAdapter value, adapter.getArray() ) {
+	for( const valijson::adapters::PropertyTreeAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isString() );
         ASSERT_FALSE( value.isNumber() );
         ASSERT_TRUE( value.maybeDouble() );
@@ -56,9 +54,9 @@ TEST_F(TestPropertyTreeAdapter, BasicObjectIteration)
     // strings their corresponding numeric values
     boost::property_tree::ptree document;
     for (unsigned int i = 0; i < numElements; i++) {
-        std::string name(boost::lexical_cast<std::string>(i));
+        std::string name(std::to_string(i));
         document.push_back(std::make_pair(name, boost::property_tree::ptree(
-            boost::lexical_cast<std::string>(double(i)))));
+            std::to_string(double(i)))));
     }
 
     // Ensure that wrapping the document preserves the object and does not
@@ -75,11 +73,11 @@ TEST_F(TestPropertyTreeAdapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::PropertyTreeAdapter::ObjectMember member, adapter.getObject() ) {
+	for( const valijson::adapters::PropertyTreeAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isString() );
         ASSERT_FALSE( member.second.isNumber() );
         ASSERT_TRUE( member.second.maybeDouble() );
-        EXPECT_EQ( boost::lexical_cast<std::string>(expectedValue), member.first );
+        EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.asDouble() );
         expectedValue++;
     }

--- a/tests/test_property_tree_adapter.cpp
+++ b/tests/test_property_tree_adapter.cpp
@@ -34,7 +34,7 @@ TEST_F(TestPropertyTreeAdapter, BasicArrayIteration)
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::PropertyTreeAdapter value : adapter.getArray() ) {
+    for( const valijson::adapters::PropertyTreeAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isString() );
         ASSERT_FALSE( value.isNumber() );
         ASSERT_TRUE( value.maybeDouble() );
@@ -73,7 +73,7 @@ TEST_F(TestPropertyTreeAdapter, BasicObjectIteration)
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::PropertyTreeAdapter::ObjectMember member : adapter.getObject() ) {
+    for( const valijson::adapters::PropertyTreeAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isString() );
         ASSERT_FALSE( member.second.isNumber() );
         ASSERT_TRUE( member.second.maybeDouble() );

--- a/tests/test_rapidjson_adapter.cpp
+++ b/tests/test_rapidjson_adapter.cpp
@@ -1,5 +1,4 @@
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -38,7 +37,7 @@ void testBasicArrayIteration()
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::RapidJsonAdapter value, adapter.getArray() ) {
+	for( const valijson::adapters::RapidJsonAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -59,7 +58,7 @@ void testBasicObjectIteration()
     document.SetObject();
     for (unsigned int i = 0; i < numElements; i++) {
         rapidjson::Value name, value;
-        name.SetString(boost::lexical_cast<std::string>(i).c_str(), document.GetAllocator());
+        name.SetString(std::to_string(i).c_str(), document.GetAllocator());
         value.SetDouble(i);
         document.AddMember(name, value, document.GetAllocator());
     }
@@ -78,9 +77,9 @@ void testBasicObjectIteration()
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-    BOOST_FOREACH( const valijson::adapters::RapidJsonAdapter::ObjectMember member, adapter.getObject() ) {
+	for( const valijson::adapters::RapidJsonAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
-        EXPECT_EQ( boost::lexical_cast<std::string>(expectedValue), member.first );
+        EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );
         expectedValue++;
     }

--- a/tests/test_rapidjson_adapter.cpp
+++ b/tests/test_rapidjson_adapter.cpp
@@ -37,7 +37,7 @@ void testBasicArrayIteration()
 
     // Ensure that the elements are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::RapidJsonAdapter value : adapter.getArray() ) {
+    for( const valijson::adapters::RapidJsonAdapter value : adapter.getArray() ) {
         ASSERT_TRUE( value.isNumber() );
         EXPECT_EQ( double(expectedValue), value.getDouble() );
         expectedValue++;
@@ -77,7 +77,7 @@ void testBasicObjectIteration()
 
     // Ensure that the members are returned in the order they were inserted
     unsigned int expectedValue = 0;
-	for( const valijson::adapters::RapidJsonAdapter::ObjectMember member : adapter.getObject() ) {
+    for( const valijson::adapters::RapidJsonAdapter::ObjectMember member : adapter.getObject() ) {
         ASSERT_TRUE( member.second.isNumber() );
         EXPECT_EQ( std::to_string(expectedValue), member.first );
         EXPECT_EQ( double(expectedValue), member.second.getDouble() );

--- a/tests/test_validation_errors.cpp
+++ b/tests/test_validation_errors.cpp
@@ -1,8 +1,5 @@
 #include <iostream>
 
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include <gtest/gtest.h>
 
 #include <valijson/adapters/rapidjson_adapter.hpp>

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -2,9 +2,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include <gtest/gtest.h>
 
 #include <valijson/adapters/jsoncpp_adapter.hpp>
@@ -99,7 +96,7 @@ protected:
             ASSERT_TRUE( testCases.isArray() );
 
             // Process each test case in the file
-            BOOST_FOREACH( const AdapterType testCase, testCases.getArray() ) {
+			for( const AdapterType testCase : testCases.getArray() ) {
 
                 currentTestCase.clear();
                 currentTest.clear();
@@ -127,7 +124,7 @@ protected:
                 itr = object.find("tests");
                 ASSERT_NE( object.end(), itr );
                 ASSERT_TRUE( itr->second.isArray() );
-                BOOST_FOREACH( const AdapterType test, itr->second.getArray() ) {
+				for( const AdapterType test : itr->second.getArray() ) {
 
                     const bool strict = itr->second.hasStrictTypes();
 

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -96,7 +96,7 @@ protected:
             ASSERT_TRUE( testCases.isArray() );
 
             // Process each test case in the file
-			for( const AdapterType testCase : testCases.getArray() ) {
+            for( const AdapterType testCase : testCases.getArray() ) {
 
                 currentTestCase.clear();
                 currentTest.clear();
@@ -124,7 +124,7 @@ protected:
                 itr = object.find("tests");
                 ASSERT_NE( object.end(), itr );
                 ASSERT_TRUE( itr->second.isArray() );
-				for( const AdapterType test : itr->second.getArray() ) {
+                for( const AdapterType test : itr->second.getArray() ) {
 
                     const bool strict = itr->second.hasStrictTypes();
 

--- a/travis.sh
+++ b/travis.sh
@@ -26,22 +26,10 @@ if [[ $CXX == 'clang++' ]]; then
 	echo "Additional flags to pass to cmake: $CMAKE_FLAGS"
 fi
 
-echo "Attempting to build and run test suite with C++11 support disabled..."
-cmake $CMAKE_FLAGS -DVALIJSON_CXX11_ADAPTERS=disabled ..
+echo "Attempting to build and run test suite with C++11 support enabled..."
+cmake $CMAKE_FLAGS -DVALIJSON_CXX11_ADAPTERS=enabled ..
 VERBOSE=1 make
 ./test_suite
-
-echo "Checking if current compiler is GCC..."
-if [[ $CXX == 'g++' ]]; then
-	echo "Not building test suite with C++11 support due to ancient version of GCC on Travis CI"
-else
-	echo "Attempting to build and run test suite with C++11 support enabled..."
-	make clean
-	cmake $CMAKE_FLAGS -DVALIJSON_CXX11_ADAPTERS=enabled ..
-	VERBOSE=1 make
-	./test_suite
-fi
-
 make clean
 
 popd > /dev/null

--- a/xcode/valijson.xcodeproj/project.pbxproj
+++ b/xcode/valijson.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		462CB4C31D50940F003DC976 /* optional.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = optional.hpp; path = compat/optional.hpp; sourceTree = "<group>"; };
 		6A309D2D1C28C1FD00EF761C /* subschema.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = subschema.hpp; sourceTree = "<group>"; };
 		6A34698C1BD109A900C97DA2 /* json_reference.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = json_reference.hpp; path = internal/json_reference.hpp; sourceTree = "<group>"; };
 		6A356B0D1C1CFD020007EB8B /* uri.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = uri.hpp; path = internal/uri.hpp; sourceTree = "<group>"; };
@@ -335,6 +336,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		462CB4C41D50941E003DC976 /* compat */ = {
+			isa = PBXGroup;
+			children = (
+				462CB4C31D50940F003DC976 /* optional.hpp */,
+			);
+			name = compat;
+			sourceTree = "<group>";
+		};
 		6A477F8717D6EEF20013571C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -846,6 +855,7 @@
 		6AC78BDC17C5FC5F00674114 /* include */ = {
 			isa = PBXGroup;
 			children = (
+				462CB4C41D50941E003DC976 /* compat */,
 				6AC78BDD17C5FC6A00674114 /* valijson */,
 			);
 			name = include;


### PR DESCRIPTION
This PR removes boost from the valijson base (except for `property_tree`, of course). The test suite passes, but further tests have not been done.

This PR is mostly to open a discussion about a potential removal of boost from valijson. Feel free to close it or ask for changes.

Removing boost was ultimately pretty straightforward.

The main issues were:
- `std::optional`: Since this is C++17, I have imported a reference implementation in _include/compat/optional.hpp_. If `<optional>` is available, it will be used instead.
- `boost::iterator_facade`: Removing this needed quite a few code changes, but they were fairly mechanic and do not obfuscate the code.

All in all, I am fairly happy with the boost-less version and think it might be a good step forward for future versions.

One caveat: while Visual Studio 2015 looks fairly complete in the C++11 features department, I did not try to compile `noboost` on Windows at all.

Let me know what you think.

