### PR TITLE
Add #include cstring

### DIFF
--- a/include/valijson/internal/json_pointer.hpp
+++ b/include/valijson/internal/json_pointer.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstddef>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -89,7 +90,7 @@ inline char decodePercentEncodedChar(const std::string &digits)
  *    turning '~01' first into '~1' and then into '/', which would be
  *    incorrect (the string '~01' correctly becomes '~1' after
  *    transformation).
- * 
+ *
  * @param   begin  iterator pointing to beginning of a token
  * @param   end    iterator pointing to one character past the end of the token
  *


### PR DESCRIPTION
I ran into build issues that required me to include `cstring` in my project. I think we should probably include `cstring` here instead.