### PR TITLE
Corrected reporting of array indices violating uniqueItems constraint.

### DIFF
--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -1052,8 +1052,9 @@ public:
         bool validated = true;
         const typename AdapterType::Array::const_iterator secondLast = --targetArray.end();
         unsigned int outerIndex = 0;
-        for (typename AdapterType::Array::const_iterator outerItr = targetArray.begin(); outerItr != secondLast; ++outerItr) {
-            unsigned int innerIndex = 1;
+        typename AdapterType::Array::const_iterator outerItr = targetArray.begin();
+        for (; outerItr != secondLast; ++outerItr) {
+            unsigned int innerIndex = outerIndex + 1;
             typename AdapterType::Array::const_iterator innerItr(outerItr);
             for (++innerItr; innerItr != end; ++innerItr) {
                 if (outerItr->equalTo(*innerItr, true)) {


### PR DESCRIPTION
Consider this schema (`schema.json`):
``` JSON
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
    "tags": {
      "uniqueItems": true,
      "type": "array",
      "items": {}
    }
  },
  "required": [
    "tags"
  ],
  "additionalProperties": false,
  "definitions": {}
}
```

This document obviously violates `uniqueItems` constraint (`violator.json`):
``` JSON
{
    "tags": [ "fun", "fun", "fun" ]
}
```

Output from validation:
```
$ ./external_schema schema.json violator.json 
Validation failed.
Error #1
  context: <root>[tags]
  desc:    Elements at indexes #0 and #1 violate uniqueness constraint.
Error #2
  context: <root>[tags]
  desc:    Elements at indexes #0 and #2 violate uniqueness constraint.
Error #3
  context: <root>[tags]
  desc:    Elements at indexes #1 and #1 violate uniqueness constraint.
Error #4
  context: <root>
  desc:    Failed to validate against schema associated with property name 'tags'.
```

Third error message mentions indices **1 and 1** which is caused by wrong initiation of `innerIndex` variable.