### PR TITLE
Fix compilation with gcc 7.1.0

### DIFF
--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -5,16 +5,8 @@
 #include <stdint.h>
 #include <sstream>
 
-// This should be removed once C++17 is widely available
-#if __has_include(<optional>)
-#  include <optional>
-namespace opt = std;
-#else
-#  include <compat/optional.hpp>
-namespace opt = std::experimental;
-#endif
-
 #include <valijson/adapters/adapter.hpp>
+#include <valijson/internal/optional.hpp>
 
 namespace valijson {
 namespace adapters {

--- a/include/valijson/internal/json_pointer.hpp
+++ b/include/valijson/internal/json_pointer.hpp
@@ -9,15 +9,8 @@
 #include <stdexcept>
 #include <string>
 
-#if __has_include(<optional>)
-#  include <optional>
-namespace opt = std;
-#else
-#  include <compat/optional.hpp>
-namespace opt = std::experimental;
-#endif
-
 #include <valijson/adapters/adapter.hpp>
+#include <valijson/internal/optional.hpp>
 
 namespace valijson {
 namespace internal {

--- a/include/valijson/internal/json_reference.hpp
+++ b/include/valijson/internal/json_reference.hpp
@@ -5,13 +5,7 @@
 #include <stdexcept>
 #include <string>
 
-#if __has_include(<optional>)
-#  include <optional>
-namespace opt = std;
-#else
-#  include <compat/optional.hpp>
-namespace opt = std::experimental;
-#endif
+#include <valijson/internal/optional.hpp>
 
 namespace valijson {
 namespace internal {

--- a/include/valijson/internal/optional.hpp
+++ b/include/valijson/internal/optional.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#ifndef __VALIJSON_OPTIONAL_HPP
+#define __VALIJSON_OPTIONAL_HPP
+
+// This should be removed once C++17 is widely available
+#if __has_include(<optional>)
+#  include <optional>
+namespace opt = std;
+#else
+#  include <compat/optional.hpp>
+namespace opt = std::experimental;
+#endif
+
+#endif

--- a/include/valijson/internal/optional.hpp
+++ b/include/valijson/internal/optional.hpp
@@ -3,7 +3,7 @@
 #define __VALIJSON_OPTIONAL_HPP
 
 // This should be removed once C++17 is widely available
-#if __has_include(<optional>)
+#if __has_include(<optional>) && __cplusplus >= 201703
 #  include <optional>
 namespace opt = std;
 #else

--- a/include/valijson/subschema.hpp
+++ b/include/valijson/subschema.hpp
@@ -6,16 +6,8 @@
 
 #include <memory>
 
-// This should be removed once C++17 is widely available
-#if __has_include(<optional>)
-#  include <optional>
-namespace opt = std;
-#else
-#  include <compat/optional.hpp>
-namespace opt = std::experimental;
-#endif
-
 #include <valijson/constraints/constraint.hpp>
+#include <valijson/internal/optional.hpp>
 
 namespace valijson {
 


### PR DESCRIPTION
The header <optional> can be only used in C++17 mode, so even if it is present in the system, it is impossible to compile it in C++11 mode, you will just get compilation errors. So I limited including of header <optional> with cases, where standart is actually C++17 or above.