### PR TITLE
Fix compilation warning on 32-bit systems.

### DIFF
--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -438,7 +438,7 @@ public:
     }
 
 private:
-    size_t maxItems;
+    uint64_t maxItems;
 };
 
 /**
@@ -492,7 +492,7 @@ public:
     }
 
 private:
-    size_t maxProperties;
+    uint64_t maxProperties;
 };
 
 /**


### PR DESCRIPTION
On 32-bit systems size_t is a 32-bit type which causes the following warning:
warning: large integer implicitly truncated to unsigned type [-Woverflow]

There's no reason have size_t storage variable for uint64_t accessors.