### PR TITLE
Inclusion of current's cmake module directory for nested projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1)
 project (valijson)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(INSTALL_HEADERS "Install valijson Headers." FALSE)
 option(BUILD_EXAMPLES "Build valijson Examples." FALSE)


### PR DESCRIPTION
CMAKE_SOURCE_DIR is the path of the root CMakeLists.txt file. When using Valijson as a submodule Valijson's ./cmake diectory is not added to the cmake module path.
By using CMAKE_CURRENT_SOURCE_DIR the path of the *current* CMakeLists.txt file is used and the modules directory is properly included.