### PR TITLE
Fix places in adapter implementation where non-strict checks should be used

### DIFF
--- a/include/valijson/adapters/basic_adapter.hpp
+++ b/include/valijson/adapters/basic_adapter.hpp
@@ -757,7 +757,7 @@ public:
     {
         if (value.isBool()) {
             return true;
-        } else if (value.isString()) {
+        } else if (maybeString()) {
             std::string stringValue;
             if (value.getString(stringValue)) {
                 if (stringValue.compare("true") == 0 || stringValue.compare("false") == 0) {
@@ -773,7 +773,7 @@ public:
     {
         if (value.isNumber()) {
             return true;
-        } else if (value.isString()) {
+        } else if (maybeString()) {
             std::string s;
             if (value.getString(s)) {
                 const char *b = s.c_str();
@@ -790,7 +790,7 @@ public:
     {
         if (value.isInteger()) {
             return true;
-        } else if (value.isString()) {
+        } else if (maybeString()) {
             std::string s;
             if (value.getString(s)) {
                 std::istringstream i(s);
@@ -810,7 +810,7 @@ public:
     {
         if (value.isNull()) {
             return true;
-        } else if (value.isString()) {
+        } else if (maybeString()) {
             std::string stringValue;
             if (value.getString(stringValue)) {
                 if (stringValue.empty()) {
@@ -826,7 +826,7 @@ public:
     {
         if (value.isObject()) {
             return true;
-        } else if (value.isArray()) {
+        } else if (maybeArray()) {
             size_t arraySize;
             if (value.getArraySize(arraySize) && arraySize == 0) {
                 return true;

--- a/include/valijson/schema_parser.hpp
+++ b/include/valijson/schema_parser.hpp
@@ -1985,7 +1985,7 @@ private:
         constraints::RequiredConstraint constraint;
 
         for (const AdapterType v : node.getArray()) {
-            if (!v.isString()) {
+            if (!v.maybeString()) {
                 throw std::runtime_error("Expected required property name to "
                         "be a string value");
             }
@@ -2028,7 +2028,7 @@ private:
 
         TypeConstraint constraint;
 
-        if (node.isString()) {
+        if (node.maybeString()) {
             const TypeConstraint::JsonType type =
                     TypeConstraint::jsonTypeFromString(node.getString());
 
@@ -2039,10 +2039,10 @@ private:
 
             constraint.addNamedType(type);
 
-        } else if (node.isArray()) {
+        } else if (node.maybeArray()) {
             int index = 0;
             for (const AdapterType v : node.getArray()) {
-                if (v.isString()) {
+                if (v.maybeString()) {
                     const TypeConstraint::JsonType type =
                             TypeConstraint::jsonTypeFromString(v.getString());
 
@@ -2054,7 +2054,7 @@ private:
 
                     constraint.addNamedType(type);
 
-                } else if (v.isObject() && version == kDraft3) {
+                } else if (v.maybeObject() && version == kDraft3) {
                     const std::string childPath = nodePath + "/" +
                             std::to_string(index);
                     const Subschema *subschema = makeOrReuseSchema<AdapterType>(
@@ -2069,7 +2069,7 @@ private:
                 index++;
             }
 
-        } else if (node.isObject() && version == kDraft3) {
+        } else if (node.maybeObject() && version == kDraft3) {
             const Subschema *subschema = makeOrReuseSchema<AdapterType>(
                     rootSchema, rootNode, node, currentScope, nodePath,
                     fetchDoc, NULL, NULL, docCache, schemaCache);


### PR DESCRIPTION
While working on implementing a custom (non-strict) adapter, I noticed several places where a strict check is being used, even though this doesn't seem correct. 

I'm not sure whether these were missed during a previous update, but my adapter will not work without these changes. It's not clear to me how any non-strict adapter would work unless non-strict string checks are performed in these places, but maybe I'm missing something.

I'm also not sure whether this changeset is comprehensive: in other words, these changes made my adapter work, but I might have missed other instances of strict checks that need to be fixed.