### PR TITLE
Fix bad iterator comparaison when resolving json pointer

### DIFF
--- a/include/valijson/internal/json_pointer.hpp
+++ b/include/valijson/internal/json_pointer.hpp
@@ -215,9 +215,11 @@ inline AdapterType resolveJsonPointer(
     } else if (node.maybeObject()) {
         // Fragment must identify a member of the candidate object
         typedef typename AdapterType::Object Object;
-        typename Object::const_iterator itr = node.asObject().find(
+
+        const Object object = node.asObject();
+        typename Object::const_iterator itr = object.find(
                 referenceToken);
-        if (itr == node.asObject().end()) {
+        if (itr == object.end()) {
             throw std::runtime_error("Expected reference token to identify an "
                     "element in the current object; "
                     "actual token: " + referenceToken);

--- a/tests/test_json_pointer.cpp
+++ b/tests/test_json_pointer.cpp
@@ -104,6 +104,34 @@ std::vector<std::shared_ptr<JsonPointerTestCase> >
     testCases.push_back(testCase);
 
     {
+        rapidjson::Value nonemptyString;
+        nonemptyString.SetString("hello, world");
+
+
+        testCase = std::make_shared<JsonPointerTestCase>(
+                "Resolve '/value/foo' fails because 'value' is not an object (but a non empty string)");
+        testCase->value.SetObject();
+        testCase->value.AddMember("value", nonemptyString, allocator);
+        testCase->jsonPointer = "/value/bar";
+        testCase->expectedValue = &testCase->value;
+        testCase->expectedValue = NULL;
+        testCases.push_back(testCase);
+    }
+
+    {
+        rapidjson::Value emptyString;
+        emptyString.SetString("");
+
+        testCase = std::make_shared<JsonPointerTestCase>(
+                "Resolve '/empty/after_empty' fails because 'empty' is an empty string");
+        testCase->value.SetObject();
+        testCase->value.AddMember("empty", emptyString, allocator);
+        testCase->jsonPointer = "/empty/after_empty";
+        testCase->expectedValue = NULL;
+        testCases.push_back(testCase);
+    }
+
+    {
         rapidjson::Value testArray;
         testArray.SetArray();
         testArray.PushBack("test0", allocator);


### PR DESCRIPTION
When resolving a json pointer and use an empty string as a
referenceToken, the value is coerced as an empty object and a temporary empty
object is returned from 'asObject()'. Then we used to compare 2
iterators from 2 differents temporary empty objects.

This patch also add 2 tests when using a value (e.g. not an object) within the path.

This patch fix a crash on Ubuntu 18.04 when building with GCC 7.4.0-1ubuntu1~18.04.1.

