### PR TITLE
Fix warning C4244 on x86 target

### DIFF
--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -557,7 +557,7 @@ public:
     }
 
 private:
-    size_t minItems;
+    uint64_t minItems;
 };
 
 /**
@@ -611,7 +611,7 @@ public:
     }
 
 private:
-    size_t minProperties;
+    uint64_t minProperties;
 };
 
 /**


### PR DESCRIPTION
Warning message: "warning C4244: '=': conversion from 'uint64_t' to 'std::size_t', possible loss of data'"