### PR TITLE
Added interface target to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,16 @@ option(valijson_EXCLUDE_BOOST "Exclude Boost when building test suite." FALSE)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
+add_library(valijson INTERFACE)
+# create alias, so that user could always write target_link_libraries(... ValiJSON::valijson)
+# despite of valijson target is imported or not
+add_library(ValiJSON::valijson ALIAS valijson)
+
+include(GNUInstallDirs)
+target_include_directories(valijson INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 if(valijson_INSTALL_HEADERS)
     install(DIRECTORY include/ DESTINATION include)
 endif()

--- a/README.md
+++ b/README.md
@@ -125,6 +125,32 @@ The examples and test suite can be built using cmake:
     # Run test suite (from build directory)
     ./test_suite
 
+#### How to add this library to your cmake target ####
+
+Download this repository into your project
+
+```bash
+git clone https://github.com/tristanpenman/valijson <project-path>/third-party/valijson
+```
+
+If your project is a git repository
+
+```bash
+cd <project-path>
+git submodule add https://github.com/tristanpenman/valijson third-party/valijson
+```
+
+Before the target add the module subdirectory in your CMakeLists.txt
+
+```cmake
+set(valijson_BUILD_TESTS OFF)
+add_subdirectory(third-party/valijson)
+
+add_executable(your-executable ...)
+
+target_link_libraries(your-executable ValiJSON::valijson)
+```
+
 ### Xcode ###
 
 An Xcode project has also been provided, in the 'xcode' directory. Note that in order to run the test suite, you may need to configure the working directory for the 'test\_suite' scheme. It is recommended that you use the 'xcode' directory as the working directory.


### PR DESCRIPTION
I've modified this project because it doesn't have any interface target to link this project to your CMake project. To help people adding this library to your CMake project I've modified the readme with the following content.

Download this repository into your project

```bash
git clone https://github.com/tristanpenman/valijson <project-path>/third-party/valijson
```

If your project is a git repository

```bash
cd <project-path>
git submodule add https://github.com/tristanpenman/valijson third-party/valijson
```

Before the target add the module subdirectory in your CMakeLists.txt

```cmake
set(valijson_BUILD_TESTS OFF)
add_subdirectory(third-party/valijson)

add_executable(your-executable ...)

target_link_libraries(your-executable ValiJSON::valijson)
```