### PR TITLE
Fix compilation errors due to unused parameters

### DIFF
--- a/include/valijson/adapters/std_string_adapter.hpp
+++ b/include/valijson/adapters/std_string_adapter.hpp
@@ -94,12 +94,12 @@ public:
     explicit StdStringAdapter(const std::string &value)
       : m_value(value) { }
 
-    bool applyToArray(ArrayValueCallback fn) const override
+    bool applyToArray(ArrayValueCallback /*fn*/) const override
     {
         return maybeArray();
     }
 
-    bool applyToObject(ObjectMemberCallback fn) const override
+    bool applyToObject(ObjectMemberCallback /*fn*/) const override
     {
         return maybeObject();
     }
@@ -190,7 +190,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getArraySize(size_t &result) const override
+    bool getArraySize(size_t &/*result*/) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -200,7 +200,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getBool(bool &result) const override
+    bool getBool(bool &/*result*/) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -210,7 +210,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getDouble(double &result) const override
+    bool getDouble(double &/*result*/) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -220,7 +220,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getInteger(int64_t &result) const override
+    bool getInteger(int64_t &/*result*/) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -230,7 +230,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getNumber(double &result) const override
+    bool getNumber(double &/*result*/) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -240,7 +240,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getObjectSize(size_t &result) const override
+    bool getObjectSize(size_t &/*result*/) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -363,12 +363,12 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool operator==(const StdStringArrayValueIterator &other) const
+    bool operator==(const StdStringArrayValueIterator &/*other*/) const
     {
         return true;
     }
 
-    bool operator!=(const StdStringArrayValueIterator &other) const
+    bool operator!=(const StdStringArrayValueIterator &/*other*/) const
     {
         return false;
     }
@@ -388,7 +388,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    void advance(std::ptrdiff_t n)
+    void advance(std::ptrdiff_t /*n*/)
     {
         throw std::runtime_error("Not supported");
     }
@@ -453,7 +453,7 @@ inline StdStringObjectMemberIterator StdStringObject::end() const
     return {};
 }
 
-inline StdStringObjectMemberIterator StdStringObject::find(const std::string &propertyName) const
+inline StdStringObjectMemberIterator StdStringObject::find(const std::string &/*propertyName*/) const
 {
     return {};
 }

--- a/include/valijson/adapters/std_string_adapter.hpp
+++ b/include/valijson/adapters/std_string_adapter.hpp
@@ -94,12 +94,12 @@ public:
     explicit StdStringAdapter(const std::string &value)
       : m_value(value) { }
 
-    bool applyToArray(ArrayValueCallback /*fn*/) const override
+    bool applyToArray(ArrayValueCallback) const override
     {
         return maybeArray();
     }
 
-    bool applyToObject(ObjectMemberCallback /*fn*/) const override
+    bool applyToObject(ObjectMemberCallback) const override
     {
         return maybeObject();
     }
@@ -190,7 +190,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getArraySize(size_t &/*result*/) const override
+    bool getArraySize(size_t &) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -200,7 +200,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getBool(bool &/*result*/) const override
+    bool getBool(bool &) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -210,7 +210,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getDouble(double &/*result*/) const override
+    bool getDouble(double &) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -220,7 +220,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getInteger(int64_t &/*result*/) const override
+    bool getInteger(int64_t &) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -230,7 +230,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getNumber(double &/*result*/) const override
+    bool getNumber(double &) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -240,7 +240,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool getObjectSize(size_t &/*result*/) const override
+    bool getObjectSize(size_t &) const override
     {
         throw std::runtime_error("Not supported");
     }
@@ -363,12 +363,12 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    bool operator==(const StdStringArrayValueIterator &/*other*/) const
+    bool operator==(const StdStringArrayValueIterator &) const
     {
         return true;
     }
 
-    bool operator!=(const StdStringArrayValueIterator &/*other*/) const
+    bool operator!=(const StdStringArrayValueIterator &) const
     {
         return false;
     }
@@ -388,7 +388,7 @@ public:
         throw std::runtime_error("Not supported");
     }
 
-    void advance(std::ptrdiff_t /*n*/)
+    void advance(std::ptrdiff_t)
     {
         throw std::runtime_error("Not supported");
     }
@@ -453,7 +453,7 @@ inline StdStringObjectMemberIterator StdStringObject::end() const
     return {};
 }
 
-inline StdStringObjectMemberIterator StdStringObject::find(const std::string &/*propertyName*/) const
+inline StdStringObjectMemberIterator StdStringObject::find(const std::string &) const
 {
     return {};
 }

--- a/include/valijson/constraints/basic_constraint.hpp
+++ b/include/valijson/constraints/basic_constraint.hpp
@@ -36,7 +36,7 @@ struct BasicConstraint: Constraint
         return visitor.visit(*static_cast<const ConstraintType*>(this));
     }
 
-    Constraint * clone(CustomAlloc allocFn, CustomFree /*freeFn*/) const override
+    Constraint * clone(CustomAlloc allocFn, CustomFree) const override
     {
         void *ptr = allocFn(sizeof(ConstraintType));
         if (!ptr) {

--- a/include/valijson/constraints/basic_constraint.hpp
+++ b/include/valijson/constraints/basic_constraint.hpp
@@ -36,7 +36,7 @@ struct BasicConstraint: Constraint
         return visitor.visit(*static_cast<const ConstraintType*>(this));
     }
 
-    Constraint * clone(CustomAlloc allocFn, CustomFree freeFn) const override
+    Constraint * clone(CustomAlloc allocFn, CustomFree /*freeFn*/) const override
     {
         void *ptr = allocFn(sizeof(ConstraintType));
         if (!ptr) {


### PR DESCRIPTION
Hi.

Trying to compile `master` or `v0.3` I got a bunch of `unused parameters` errors.

I commented out the unused parameters, according to the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Function_Declarations_and_Definitions) (let me know if you prefer any other method).

Also, I noticed [you added the `-Werror -Wunused` flags](https://github.com/tristanpenman/valijson/commit/73a8e440c0d93bf09a03638c99c57dfec489b1d4), but the Travis builds did not fail despite the unused parameters. Maybe the `.travis.yml` file should be updated too?