### PR TITLE
Regex objects cache for pattern constraints

### DIFF
--- a/include/valijson/validator.hpp
+++ b/include/valijson/validator.hpp
@@ -59,7 +59,7 @@ public:
     {
         // Construct a ValidationVisitor to perform validation at the root level
         ValidationVisitor<AdapterType> v(target,
-                std::vector<std::string>(1, "<root>"), strictTypes, results);
+                std::vector<std::string>(1, "<root>"), strictTypes, results, regexesCache);
 
         return v.validateSchema(schema);
     }
@@ -68,6 +68,9 @@ private:
 
     /// Flag indicating that strict type comparisons should be used
     const bool strictTypes;
+
+    /// Cached regex objects for pattern constraint. Key - pattern.
+    std::unordered_map<std::string, std::regex> regexesCache;
 
 };
 


### PR DESCRIPTION
I have to validate lots of documents against schema with several regex patterns. Validation is quite slow because valijson creates new std::regex object for every check. With the cache validation for my use case became 10 times faster.