### PR TITLE
Add fuzzer with oss-fuzz build script

### DIFF
--- a/tests/fuzzing/fuzzer.cpp
+++ b/tests/fuzzing/fuzzer.cpp
@@ -1,0 +1,43 @@
+#include <stdexcept>
+#include <unistd.h>
+
+#include <document.h>
+#include <valijson/adapters/rapidjson_adapter.hpp>
+#include <valijson/utils/rapidjson_utils.hpp>
+#include <valijson/schema.hpp>
+#include <valijson/schema_parser.hpp>
+
+using valijson::Schema;
+using valijson::SchemaParser;
+using valijson::adapters::RapidJsonAdapter;
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if(size<3) return 0;
+    char input_file[256];
+    sprintf(input_file, "/tmp/libfuzzer.json");
+    FILE *fp = fopen(input_file, "wb");
+    if (!fp)
+        return 0;
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    rapidjson::Document schemaDocument;
+    if (!valijson::utils::loadDocument(input_file, schemaDocument)) {
+        return 1;
+    }
+    
+    Schema schema;
+    SchemaParser parser;
+    RapidJsonAdapter schemaDocumentAdapter(schemaDocument);
+    try {
+        parser.populateSchema(schemaDocumentAdapter, schema);
+    } catch (std::exception &e) {
+        unlink(input_file);
+        return 1;
+    }
+
+    unlink(input_file);
+    return 1;
+}

--- a/tests/fuzzing/oss-fuzz-build.sh
+++ b/tests/fuzzing/oss-fuzz-build.sh
@@ -5,7 +5,7 @@ sed -i '27d' include/valijson/utils/rapidjson_utils.hpp
 
 mkdir build
 cd build
-cmake 	-Dvalijson_BUILD_EXAMPLES=FALSE \
+cmake -Dvalijson_BUILD_EXAMPLES=FALSE \
 	-Dvalijson_EXCLUDE_BOOST=TRUE \
 	..
 

--- a/tests/fuzzing/oss-fuzz-build.sh
+++ b/tests/fuzzing/oss-fuzz-build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+
+# This line causes an abort which breaks fuzzing:
+sed -i '27d' include/valijson/utils/rapidjson_utils.hpp
+
+mkdir build
+cd build
+cmake 	-Dvalijson_BUILD_EXAMPLES=FALSE \
+	-Dvalijson_EXCLUDE_BOOST=TRUE \
+	..
+
+make -j$(nproc)
+
+cd ../tests/fuzzing
+
+find ../.. -name "*.o" -exec ar rcs fuzz_lib.a {} \;
+
+$CXX $CXXFLAGS -DVALIJSON_USE_EXCEPTIONS=1 \
+	-I/src/valijson/thirdparty/rapidjson-1.1.0/include \
+	-I/src/valijson/thirdparty/rapidjson-1.1.0/include/rapidjson \
+	-I/src/valijson/include \
+	-I/src/valijson/include/valijson \
+	-I/src/valijson/include/valijson/adapters \
+	-c fuzzer.cpp -o fuzzer.o
+
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+	-DVALIJSON_USE_EXCEPTIONS=1 \
+	-rdynamic fuzzer.o \
+	-o $OUT/fuzzer fuzz_lib.a
+
+zip $OUT/fuzzer_seed_corpus.zip \
+	$SRC/valijson/doc/schema/draft-03.json


### PR DESCRIPTION
This PR adds a fuzzer with a build script to build the fuzzer on the OSS-fuzz project.

Fuzzing is a way of testing whereby pseudo-random data is passed to an application with the goal of finding bugs and vulnerabilities.

Integration into OSS-fuzz will allow the fuzzer to be run continuously to find deeper bugs, and all future fuzzers can be set up to run continuously as well. If a bug is found, all valijson maintainers get notified with an email containing a link to a detailed bug report with stack trace and reproducible test case for debugging. The service is offered free of charge with an implied expectation that bugs are fixed, so that the resources spent on fuzzing valijson go towards resolving bugs in the code base.

I will shortly be setting up the necessary files on the OSS-fuzz side, and when that is ready, the files in this PR need to be merged and at least one maintainers email address is needed on the OSS-fuzz side in order to complete the integration. 