### PR TITLE
update README add with cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ git submodule add https://github.com/tristanpenman/valijson third-party/valijson
 Before the target add the module subdirectory in your CMakeLists.txt
 
 ```cmake
-set(valijson_BUILD_TESTS OFF)
+set(valijson_BUILD_TESTS OFF CACHE BOOL "don't build valijson tests")
 add_subdirectory(third-party/valijson)
 
 add_executable(your-executable ...)


### PR DESCRIPTION
With newer CMake version (3.13) the behaviour of the option() function has changed under policy CMP0077. The option() function no longer honours normal variables. Therefore, here i'm suggesting that to disable building tests we set a cache variable which is honoured by the the option() function.