### PR TITLE
Smart pointer memory management

### DIFF
--- a/include/valijson/constraints/basic_constraint.hpp
+++ b/include/valijson/constraints/basic_constraint.hpp
@@ -39,7 +39,8 @@ struct BasicConstraint: Constraint
     OwningPointer clone(CustomAlloc allocFn, CustomFree freeFn) const override
     {
         // smart pointer to automatically free raw memory on exception
-        auto ptr = std::unique_ptr<void, CustomFree>(allocFn(sizeof(ConstraintType)), freeFn);
+        typedef std::unique_ptr<Constraint, CustomFree> RawOwningPointer;
+        auto ptr = RawOwningPointer(static_cast<Constraint*>(allocFn(sizeof(ConstraintType))), freeFn);
         if (!ptr) {
             throwRuntimeError("Failed to allocate memory for cloned constraint");
         }
@@ -47,8 +48,8 @@ struct BasicConstraint: Constraint
         // constructor might throw but the memory will be taken care of anyways
         (void)new (ptr.get()) ConstraintType(*static_cast<const ConstraintType*>(this));
 
-        // reassign managed memory to smart pointer that will also destroy object instance
-        return OwningPointer(static_cast<const Constraint*>(ptr.release()), freeFn);
+        // implicitly convert to smart pointer that will also destroy object instance
+        return ptr;
     }
 
 protected:

--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -906,7 +906,8 @@ public:
     OwningPointer clone(CustomAlloc allocFn, CustomFree freeFn) const override
     {
         // smart pointer to automatically free raw memory on exception
-        auto ptr = std::unique_ptr<void, CustomFree>(allocFn(sizeOf()), freeFn);
+        typedef std::unique_ptr<Constraint, CustomFree> RawOwningPointer;
+        auto ptr = RawOwningPointer(static_cast<Constraint*>(allocFn(sizeOf())), freeFn);
         if (!ptr) {
             throwRuntimeError("Failed to allocate memory for cloned constraint");
         }
@@ -914,8 +915,8 @@ public:
         // constructor might throw but the memory will be taken care of anyways
         (void)cloneInto(ptr.get());
 
-        // reassign managed memory to smart pointer that will also destroy object instance
-        return OwningPointer(static_cast<const Constraint*>(ptr.release()), freeFn);
+        // implicitly convert to smart pointer that will also destroy object instance
+        return ptr;
     }
 
     virtual bool validate(const adapters::Adapter &target,


### PR DESCRIPTION
Currently, the use of `CustomAllocator` in constraint handling adds lots of overhead to the constraint management to handle safe memory freeing. This PR adds a deleter type for use with `std::unique_ptr`/`std::shared_ptr` and uses it to get rid of manual memory freeing. This simplifies the conditional exception handling, as there is no need for manual memory freeing within catch blocks. Might solve https://github.com/tristanpenman/valijson/issues/115

The `CustomDeleter` type is intentionally written in a general fashion to allow easy reuse with types other than `Constraint`.

Tested with GCC8 in Debian and MSVC19.