### PR TITLE
make shellcheck clean

### DIFF
--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#
+# Shellcheck is a static analyzer for shell scripts: https://shellcheck.net/
+# It is available in several operating systems and also as a docker image.
+#
+# If it finds any issues, it will output a small blurb describing the affected
+# line(s) and will have a generic issue ID. The issue ID can be opened on its
+# website to learn more about what the underlying problem is, why it's a
+# problem, and (usually) suggests a way to fix.
+# Specific shellcheck issues can be disabled (aka silenced). Doing so is
+# usually pretty loud during code review.
+# https://github.com/koalaman/shellcheck/wiki/Directive
+
+# https://stackoverflow.com/a/2871034/1111557
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SHELLCHECK="${SHELLCHECK:-"/usr/bin/shellcheck"}"
+SEARCH_DIR="${SEARCH_DIR:-"$HERE"}"
+cd "${SEARCH_DIR}" #so that we can call git
+
+#
+# This block will:
+# 1) `find` files under `SEARCH_DIR`
+# 2) skip anything under `/thirdparty/`, `/.git/`
+# 3) in a loop reading each path:
+# 3a) ignore files that git also ignores
+# 3b) use `file` to filter only script files
+# 3c) run shellcheck against that script
+# 4) if any paths are found to have an error, their paths are collated.
+FAILED_PATHS=()
+while read -r file_path
+do
+  if git rev-parse --git-dir > /dev/null 2>&1;
+  then
+    git check-ignore --quiet "${file_path}" && continue
+  fi
+  file "${file_path}" | grep -q 'shell script' || continue
+  SCRIPT_PATH="${file_path}"
+  echo "Checking: ${SCRIPT_PATH}"
+  "${SHELLCHECK}" \
+    "${SCRIPT_PATH}" \
+  || FAILED_PATHS+=( "${SCRIPT_PATH}" )
+done < <(
+  find "${SEARCH_DIR}" -type f \
+  | grep -v '/\.git/\|/thirdparty/'
+)
+
+#
+# If there are any failed paths, summarize them here.
+# Then report a failing status to our caller.
+if [[ 0 -lt "${#FAILED_PATHS[@]}" ]]; then
+  >&2 echo "These scripts aren't shellcheck-clean:"
+  for path in "${FAILED_PATHS[@]}"; do
+    >&2 echo "${path}"
+  done
+  exit 1
+fi
+
+# If we get here, then none of the scripts had any warnings.
+echo "All scripts found (listed above) passed shellcheck"

--- a/tests/fuzzing/oss-fuzz-build.sh
+++ b/tests/fuzzing/oss-fuzz-build.sh
@@ -9,13 +9,15 @@ cmake -Dvalijson_BUILD_EXAMPLES=FALSE \
 	-Dvalijson_EXCLUDE_BOOST=TRUE \
 	..
 
-make -j$(nproc)
+make -j"$(nproc)"
 
 cd ../tests/fuzzing
 
 find ../.. -name "*.o" -exec ar rcs fuzz_lib.a {} \;
 
-$CXX $CXXFLAGS -DVALIJSON_USE_EXCEPTIONS=1 \
+# CXXFLAGS may contain spaces
+# shellcheck disable=SC2086
+"$CXX" $CXXFLAGS -DVALIJSON_USE_EXCEPTIONS=1 \
 	-I/src/valijson/thirdparty/rapidjson-48fbd8c/include \
 	-I/src/valijson/thirdparty/rapidjson-48fbd8c/include/rapidjson \
 	-I/src/valijson/include \
@@ -23,10 +25,11 @@ $CXX $CXXFLAGS -DVALIJSON_USE_EXCEPTIONS=1 \
 	-I/src/valijson/include/valijson/adapters \
 	-c fuzzer.cpp -o fuzzer.o
 
-$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+# shellcheck disable=SC2086
+"$CXX" $CXXFLAGS "$LIB_FUZZING_ENGINE" \
 	-DVALIJSON_USE_EXCEPTIONS=1 \
 	-rdynamic fuzzer.o \
-	-o $OUT/fuzzer fuzz_lib.a
+	-o "${OUT}/fuzzer fuzz_lib.a"
 
-zip $OUT/fuzzer_seed_corpus.zip \
-	$SRC/valijson/doc/schema/draft-03.json
+zip "${OUT}/fuzzer_seed_corpus.zip" \
+	"${SRC}/valijson/doc/schema/draft-03.json"


### PR DESCRIPTION
Hi, valijson is pretty handy. I've used it as a dependency. The parent project also runs shellcheck on everything and valijson showed up with some issues. This tries to fix them. I haven't added it to your `.travis.yml` file; I do recommend it gets added but I'll let you decide that.

Compare:
`$ bash ./shellcheck.sh`

Old:
```
Checking: /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh

In /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh line 12:
make -j$(nproc)
       ^------^ SC2046: Quote this to prevent word splitting.


In /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh line 18:
$CXX $CXXFLAGS -DVALIJSON_USE_EXCEPTIONS=1 \
     ^-------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
$CXX "$CXXFLAGS" -DVALIJSON_USE_EXCEPTIONS=1 \


In /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh line 26:
$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
     ^-------^ SC2086: Double quote to prevent globbing and word splitting.
               ^-----------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
$CXX "$CXXFLAGS" "$LIB_FUZZING_ENGINE" \


In /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh line 29:
        -o $OUT/fuzzer fuzz_lib.a
           ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
        -o "$OUT"/fuzzer fuzz_lib.a


In /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh line 31:
zip $OUT/fuzzer_seed_corpus.zip \
    ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
zip "$OUT"/fuzzer_seed_corpus.zip \


In /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh line 32:
        $SRC/valijson/doc/schema/draft-03.json
        ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
        "$SRC"/valijson/doc/schema/draft-03.json

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
Checking: /home/kbennett/src/public/valijson/shellcheck-.sh
These scripts aren't shellcheck-clean:
/home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh
```

Now:
```
Checking: /home/kbennett/src/public/valijson/tests/fuzzing/oss-fuzz-build.sh
Checking: /home/kbennett/src/public/valijson/shellcheck.sh
All scripts found (listed above) passed shellcheck
```

Note that this doesn't fix shellcheck complaints in the upstream googletest; I've filtered out `thirdparty` for that.
