### PR TITLE
Fix memory leak in ConstConstraint

### DIFF
--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -192,6 +192,11 @@ public:
       : BasicConstraint(other),
         m_value(other.m_value->clone()) { }
 
+    ~ConstConstraint() override
+    {
+        delete m_value;
+    }
+
     adapters::FrozenValue * getValue() const
     {
         return m_value.get();


### PR DESCRIPTION
This issue should up when we run some tests with enabled address sanitizer.