### PR TITLE
Fixed PocoJsonValue::getInteger being limited to 32-bit integers

### DIFF
--- a/include/valijson/adapters/poco_json_adapter.hpp
+++ b/include/valijson/adapters/poco_json_adapter.hpp
@@ -346,7 +346,7 @@ public:
     bool getInteger(int64_t &result) const
     {
         if (m_value.isInteger()) {
-            result = m_value.convert<int>();
+            result = m_value.convert<int64_t>();
             return true;
         }
         return false;


### PR DESCRIPTION
The Poco JSON adapter previously implemented the `getInteger` method by calling `m_value.convert<int>()` to extract a value.
This means that when an integer is present that is outside the 32-bit signed integer range, the internal Poco::Dynamic::Var will throw a Poco::RangeException.
This method is now updated to actually convert to the int64_t type directly.