### PR TITLE
Fix isString() method in yaml_cpp_adapter

### DIFF
--- a/include/valijson/adapters/yaml_cpp_adapter.hpp
+++ b/include/valijson/adapters/yaml_cpp_adapter.hpp
@@ -433,7 +433,7 @@ class YamlCppValue
 
     bool isString() const
     {
-        return true;
+        return m_value.isScalar();
     }
 
   private:


### PR DESCRIPTION
Hi @tristanpenman, @psigen,

First of all, thanks for the amazing work in this library, super cool!

I've tried the `yaml_cpp_adapter` to validate a YAML file with a custom JSON schema and experience runtime errors when the YAML app included arrays of objects, for example
```
start:
  test:
    - { name: one, value: two }
    - { name: ten, value: twenty }
```
and I seem to have found the bug that was causing these runtime errors. While it's true that each element in a YAML should be considered as string (hence probably the `return true` in the `isString()` method), this should only return true when the element is actually a scalar value and not a sequence or a map.

Happy to hear your feedback.