### PR TITLE
Added explicit default move constructors/operators

### DIFF
--- a/include/valijson/schema.hpp
+++ b/include/valijson/schema.hpp
@@ -42,6 +42,12 @@ public:
     // Disable copy assignment
     Schema & operator=(const Schema &) = delete;
 
+    // Default move construction
+    Schema(Schema &&other) = default;
+
+    // Disable copy assignment
+    Schema & operator=(Schema &&) = default;
+
     /**
      * @brief  Clean up and free all memory managed by the Schema
      *

--- a/include/valijson/subschema.hpp
+++ b/include/valijson/subschema.hpp
@@ -43,6 +43,12 @@ public:
     // Disable copy assignment
     Subschema & operator=(const Subschema &) = delete;
 
+    // Default move construction
+    Subschema(Subschema &&) = default;
+
+    // Default move assignment
+    Subschema & operator=(Subschema &&) = default;
+
     /**
      * @brief  Construct a new Subschema object
      */


### PR DESCRIPTION
Got into a situation where an object that contained a Schema member was intended to be moved into a vector.
Before this was not possible to do, since the Schema and Subschema classes both did not have move constructors/operators.
Luckily all of their members are able to be moved, so defining the default implementation was sufficient.

Changes:
- Added explicit default move constructor/operator to Schema and Subschema to enable move semantics for these classes.