### PR TITLE
Compatibility with boost-1.85.0

### DIFF
--- a/examples/boost_json_example.cpp
+++ b/examples/boost_json_example.cpp
@@ -45,7 +45,7 @@ const auto targetJson = R"({
 
 int main()
 {
-    json::error_code ec;
+    boost::system::error_code ec;
     auto schemaDoc = json::parse(schemaJson, ec);
     if (ec) {
         std::cerr << "Error parsing schema json: " << ec.message() << std::endl;

--- a/include/valijson/utils/boost_json_utils.hpp
+++ b/include/valijson/utils/boost_json_utils.hpp
@@ -23,7 +23,7 @@ inline bool loadDocument(const std::string &path, boost::json::value &document)
 #if VALIJSON_USE_EXCEPTIONS
     try {
 #endif
-      boost::json::error_code errorCode;
+      boost::system::error_code errorCode;
       boost::json::string_view stringView{file};
       document = boost::json::parse(stringView, errorCode);
         if (errorCode) {


### PR DESCRIPTION
Starting from boost version 1.85.0, json::error_code is now deprecated

Changes added here:
https://github.com/boostorg/json/commit/bacc644f93c9b2000cd137ebf541ad754d6ca747