### PR TITLE
Ability to customize regular expression engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ if(valijson_BUILD_TESTS)
         tests/test_poly_constraint.cpp
         tests/test_validation_errors.cpp
         tests/test_validator.cpp
+        tests/test_validator_with_custom_regular_expression_engine.cpp
         tests/test_yaml_cpp_adapter.cpp
     )
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,34 @@ Validator validator(Validator::kWeakTypes);
 
 This will create a validator that will attempt to cast values to satisfy a schema. The original motivation for this was to support the Boost Property Tree library, which can parse JSON, but stores values as strings.
 
+## Regular Expression Engine
+
+When enforcing a 'pattern' property, a regular expression engine is in used. By default, the DefaultRegexEngine use std::regex.
+std::regex has no protection against catastrophic backtracking and implementation with gcc is so suboptimal that it can easily leads to segmentation fault.
+One can customise the regular expression engine by implementing it's own wrapper to it and using a ValidatorT with the custom type.
+
+The regular expression engine wrapper must implement the following interface
+```cpp
+struct MyRegexpEngine
+{
+    MyRegexpEngine(const std::string& pattern)
+    {
+        //implementation specific
+    }
+
+    static bool search(const std::string& s, const MyRegexpEngine& r)
+    {
+	    //implementation specific
+    }
+};
+
+```
+
+Then to use it
+```cpp
+    using MyValidator = ValidatorT<MyRegexpEngine>;
+```
+
 ## Memory Management
 
 Valijson has been designed to safely manage, and eventually free, the memory that is allocated while parsing a schema or validating a document. When working with an externally loaded schema (i.e. one that is populated using the `SchemaParser` class) you can rely on RAII semantics.

--- a/include/valijson/validator.hpp
+++ b/include/valijson/validator.hpp
@@ -8,10 +8,15 @@ namespace valijson {
 class Schema;
 class ValidationResults;
 
+
 /**
- * @brief  Class that provides validation functionality.
+ * @brief   Class that provides validation functionality.
+ *
+ * @tparam  RegexEngine regular expression engine used for pattern constraint validation.
+
  */
-class Validator
+template <typename RegexEngine>
+class ValidatorT
 {
 public:
     enum TypeCheckingMode
@@ -23,7 +28,7 @@ public:
     /**
      * @brief  Construct a Validator that uses strong type checking by default
      */
-    Validator()
+    ValidatorT()
       : strictTypes(true) { }
 
     /**
@@ -31,7 +36,7 @@ public:
      *
      * @param  typeCheckingMode  choice of strong or weak type checking
      */
-    Validator(TypeCheckingMode typeCheckingMode)
+    ValidatorT(TypeCheckingMode typeCheckingMode)
       : strictTypes(typeCheckingMode == kStrongTypes) { }
 
     /**
@@ -58,7 +63,7 @@ public:
             ValidationResults *results)
     {
         // Construct a ValidationVisitor to perform validation at the root level
-        ValidationVisitor<AdapterType> v(target,
+        ValidationVisitor<AdapterType, RegexEngine> v(target,
                 std::vector<std::string>(1, "<root>"), strictTypes, results, regexesCache);
 
         return v.validateSchema(schema);
@@ -70,7 +75,25 @@ private:
     bool strictTypes;
 
     /// Cached regex objects for pattern constraint. Key - pattern.
-    std::unordered_map<std::string, std::regex> regexesCache;
+    std::unordered_map<std::string, RegexEngine> regexesCache;
 };
 
+/**
+ * @brief   Struct that provides a default Regular Expression Engine using std::regex
+ *
+ */
+struct DefaultRegexEngine
+{
+    DefaultRegexEngine(const std::string& pattern)
+	: regex(pattern) { }
+
+    static bool search(const std::string& s, const DefaultRegexEngine& r)
+    {
+	    return std::regex_search(s, r.regex);
+    }
+    std::regex regex;
+};
+    
+using Validator = ValidatorT<DefaultRegexEngine>;
+    
 }  // namespace valijson

--- a/tests/test_validator_with_custom_regular_expression_engine.cpp
+++ b/tests/test_validator_with_custom_regular_expression_engine.cpp
@@ -1,0 +1,128 @@
+#ifdef _MSC_VER
+#pragma warning(disable: 4706)
+#include <picojson.h>
+#pragma warning(default: 4706)
+#else
+#include <picojson.h>
+#endif
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <valijson/adapters/json11_adapter.hpp>
+#include <valijson/adapters/jsoncpp_adapter.hpp>
+#include <valijson/adapters/rapidjson_adapter.hpp>
+#include <valijson/adapters/picojson_adapter.hpp>
+#include <valijson/adapters/nlohmann_json_adapter.hpp>
+#include <valijson/utils/json11_utils.hpp>
+#include <valijson/utils/jsoncpp_utils.hpp>
+#include <valijson/utils/picojson_utils.hpp>
+#include <valijson/utils/rapidjson_utils.hpp>
+#include <valijson/utils/nlohmann_json_utils.hpp>
+#include <valijson/schema.hpp>
+#include <valijson/schema_parser.hpp>
+#include <valijson/validation_results.hpp>
+#include <valijson/validator.hpp>
+#include <valijson/exceptions.hpp>
+#ifdef VALIJSON_BUILD_POCO_ADAPTER
+#include <valijson/adapters/poco_json_adapter.hpp>
+#include <valijson/utils/poco_json_utils.hpp>
+#endif
+
+using valijson::adapters::AdapterTraits;
+using valijson::adapters::RapidJsonAdapter;
+using valijson::Schema;
+using valijson::SchemaParser;
+using valijson::Validator;
+
+namespace
+{
+void createFileFromContent(const std::string& filename, const std::string& content)
+{
+    std::ofstream outfile(filename, std::ofstream::out | std::ofstream::trunc);
+    outfile << content << std::endl;
+    outfile.close();
+};
+    
+}
+
+//Potentially :
+// Define a struct CustomRegexEngine that handle both problem and use it as replacement of Validator..
+//using CustomValidator = ValidatorT<CustomRegexEngine>;
+
+TEST(valijson, valijson_be_robust_against_bad_regular_expression)
+{
+    GTEST_SKIP() << "Skipping begin it cause segmentation fault with default Validator";
+    const std::string schema = R"(
+    {
+        "properties": {
+	        "text": {
+	            "pattern": "^[\\s\\S]+$",
+	            "type": "string"
+        	}
+        }
+	}
+    )";
+    
+    createFileFromContent("schema.json", schema);
+    rapidjson::Document mySchemaDoc;
+    ASSERT_TRUE(valijson::utils::loadDocument("schema.json", mySchemaDoc));
+    
+    Schema mySchema;
+    SchemaParser parser;
+    RapidJsonAdapter mySchemaAdapter(mySchemaDoc);
+    parser.populateSchema(mySchemaAdapter, mySchema);
+    rapidjson::Document myTargetDoc;
+    std::string payload = "{ \"text\" :  \"";
+    for (int i = 0; i< 100000; ++i)
+	payload += 'A';
+    payload += "\"}";
+	    
+    createFileFromContent("payload.json", payload);
+    
+    ASSERT_TRUE(valijson::utils::loadDocument("payload.json", myTargetDoc));
+
+    //This test crash (segfault) is validator is not customized with custom RegexpEngine
+    Validator validator;
+    RapidJsonAdapter myTargetAdapter(myTargetDoc);
+    ASSERT_TRUE(validator.validate(mySchema, myTargetAdapter, nullptr));
+}
+
+TEST(valijson, valijson_be_robust_against_catastrophic_backtracking_regular_expression)
+{
+    GTEST_SKIP() << "Skipping begin it hangs due to non management of catastrophic backtracking with default Validator";
+    
+    const std::string schema = R"(
+    {
+        "properties": {
+	        "text": {
+	            "pattern": "((A+)*)+$",
+	            "type": "string"
+        	}
+        }
+	}
+    )";
+    
+    createFileFromContent("schema.json", schema);
+    rapidjson::Document mySchemaDoc;
+    ASSERT_TRUE(valijson::utils::loadDocument("schema.json", mySchemaDoc));
+    
+    Schema mySchema;
+    SchemaParser parser;
+    RapidJsonAdapter mySchemaAdapter(mySchemaDoc);
+    parser.populateSchema(mySchemaAdapter, mySchema);
+    rapidjson::Document myTargetDoc;
+    std::string payload = "{ \"text\" :  \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC\"}";
+	    
+    createFileFromContent("payload.json", payload);
+    
+    ASSERT_TRUE(valijson::utils::loadDocument("payload.json", myTargetDoc));
+
+    //This test takes endless time if validator is not customized with custom RegexpEngine
+    Validator validator;
+    RapidJsonAdapter myTargetAdapter(myTargetDoc);
+
+    //payload is correct regarding the regexp but evaluation is impossible due to catastrophic regexp bactracking. so we return false.
+    ASSERT_FALSE(validator.validate(mySchema, myTargetAdapter, nullptr));
+}


### PR DESCRIPTION
class Validator becomes a templated type accepting a RegexEngine type which perform the regular expression creation and matching for the pattern constraint.

Provide the DefaultRegexEngine which perform exactly as of today (using std::regex). No breaking changes in library user.

(note that other place where std::regex are in used are not changed, (.i.e format constraint) because they are not likely to cause issue (regular expression is hard coded, not coming from the schema). 

Add 2 examples with gtest_skip that can easily be uncommented to exercice the 2 problems.

Not added, because I don't want to add new dependency in the project : a full example of what can be a CustomRegexEngine class handling both problem. This can be done with pcre which allows to set 
`match_limit`  and `match_limit_recursion`  on a pcre_extra struct that can be passed to the pcre_exec.
In case theses limits are reached obviously we are not able to really know if the payload match the pattern but we can safely handle this without crash or infinite recursion.

This solution also gives library user the ability to choose any Regular Expression engine depending on its use case.