### PR TITLE
build: Add bundle.sh for deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ install(EXPORT valijsonConfig
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/valijson"
 )
 
+install(FILES bundle.sh
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+  
 if(NOT valijson_BUILD_TESTS AND NOT valijson_BUILD_EXAMPLES)
     return()
 endif()


### PR DESCRIPTION
The bundle.sh script is useful and should be included for deployment for people to use.
