### PR TITLE
Fix buffer overflow in u8_strlen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ if(valijson_BUILD_TESTS)
         tests/test_validator.cpp
         tests/test_validator_with_custom_regular_expression_engine.cpp
         tests/test_yaml_cpp_adapter.cpp
+        tests/test_utf8_utils.cpp
     )
 
     set(TEST_LIBS gtest gtest_main jsoncpp json11 yamlcpp)

--- a/include/valijson/utils/utf8_utils.hpp
+++ b/include/valijson/utils/utf8_utils.hpp
@@ -14,50 +14,39 @@
 namespace valijson {
 namespace utils {
 
-static const uint32_t offsetsFromUTF8[6] = {
-    0x00000000UL, 0x00003080UL, 0x000E2080UL,
-    0x03C82080UL, 0xFA082080UL, 0x82082080UL
-};
-
 /* is c the start of a utf8 sequence? */
-inline bool isutf(char c) {
-    return ((c & 0xC0) != 0x80);
-}
-
-/* reads the next utf-8 sequence out of a string, updating an index */
-inline uint64_t u8_nextchar(const char *s, uint64_t *i)
+inline bool isutf(char c)
 {
-    uint64_t ch = 0;
-    int sz = 0;
-
-    do {
-        ch <<= 6;
-        ch += static_cast<unsigned char>(s[(*i)++]);
-        sz++;
-    } while (s[*i] && !isutf(s[*i]));
-    ch -= offsetsFromUTF8[sz-1];
-
-    return ch;
+    return ((c & 0xC0) != 0x80);
 }
 
 /* number of characters */
 inline uint64_t u8_strlen(const char *s)
 {
-    constexpr auto maxLength = std::numeric_limits<uint64_t>::max();
     uint64_t count = 0;
-    uint64_t i = 0;
 
-    while (s[i] != 0 && u8_nextchar(s, &i) != 0) {
-        if (i == maxLength) {
-            throwRuntimeError(
-                    "String exceeded maximum size of " +
-                    std::to_string(maxLength) + " bytes.");
+    while (*s) {
+        unsigned char p = static_cast<unsigned char>(*s);
+
+        size_t seqLen = p < 0x80   ? 1  // 0xxxxxxx: 1-byte (ASCII)
+                        : p < 0xE0 ? 2  // 110xxxxx: 2-byte sequence
+                        : p < 0xF0 ? 3  // 1110xxxx: 3-byte sequence
+                        : p < 0xF8 ? 4  // 11110xxx: 4-byte sequence
+                                   : 1; // treat as a single character
+
+        for (size_t i = 1; i < seqLen; ++i) {
+            if (s[i] == 0 || isutf(s[i])) {
+                seqLen = i;
+                break;
+            }
         }
+
+        s += seqLen;
         count++;
     }
 
     return count;
 }
 
-}  // namespace utils
-}  // namespace valijson
+} // namespace utils
+} // namespace valijson

--- a/tests/test_utf8_utils.cpp
+++ b/tests/test_utf8_utils.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include <valijson/utils/utf8_utils.hpp>
+
+class TestUtf8Utils : public testing::Test
+{
+};
+
+TEST_F(TestUtf8Utils, Utf8StringLength)
+{
+    using valijson::utils::u8_strlen;
+
+    EXPECT_EQ(u8_strlen(""), 0);
+    EXPECT_EQ(u8_strlen("a"), 1);
+    EXPECT_EQ(u8_strlen("abc"), 3);
+
+    // U+0416
+    EXPECT_EQ(u8_strlen("\xD0\x96"), 1);
+
+    // U+0915
+    EXPECT_EQ(u8_strlen("\xE0\xA4\x95"), 1);
+
+    // U+10348
+    EXPECT_EQ(u8_strlen("\xF0\x90\x8D\x88"), 1);
+
+    // U+0915 + U+0416
+    EXPECT_EQ(u8_strlen("\xE0\xA4\x95\xD0\x96"), 2);
+
+    // incomplete U+0416 at the end
+    EXPECT_EQ(u8_strlen("\xD0"), 1);
+
+    // incomplete U+0416 in the middle
+    EXPECT_EQ(u8_strlen("\320abc"), 4);
+
+    // incomplete U+0915 at the end
+    EXPECT_EQ(u8_strlen("\xE0\xA4"), 1);
+
+    // incomplete U+0915 at the end
+    EXPECT_EQ(u8_strlen("\xE0\244abc"), 4);
+
+    // U+DFFF
+    EXPECT_EQ(u8_strlen("\xED\xBF\xBF"), 1);
+
+    // Overlong encoding for U+0000
+    EXPECT_EQ(u8_strlen("\xC0\x80"), 1);
+
+    // U+110000 (out of Unicode range)
+    EXPECT_EQ(u8_strlen("\xF5\x80\x80\x80"), 1);
+
+    // 0xE0 + 0xA4 repeating 9 times
+    EXPECT_EQ(u8_strlen("\340\244\244\244\244\244\244\244\244\244"), 5);
+}


### PR DESCRIPTION
This patch fixes a buffer overflow error in the `u8_strlen` function that happened with invalid UTF-8 input. I added one unit test and it failed without the fix with the following error:

```
=================================================================
==1789377==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5586e133a5e4 at pc 0x5586e0f09b29 bp 0x7fff5e81a430 sp 0x7fff5e81a420
READ of size 4 at 0x5586e133a5e4 thread T0
    #0 0x5586e0f09b28 in valijson::utils::u8_nextchar(char const*, unsigned long*) valijson/include/valijson/utils/utf8_utils.hpp:38
    #1 0x5586e0f09eaf in valijson::utils::u8_strlen(char const*) valijson/include/valijson/utils/utf8_utils.hpp:50
    #2 0x5586e11bf014 in TestUtf8Utils_Utf8StringLength_Test::TestBody() valijson/tests/test_utf8_utils.cpp:50
    #3 0x5586e125b0af in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) valijson/thirdparty/googletest/googletest/src/gtest.cc:2599
    #4 0x5586e124a4c0 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) valijson/thirdparty/googletest/googletest/src/gtest.cc:2635
    #5 0x5586e11f93fd in testing::Test::Run() valijson/thirdparty/googletest/googletest/src/gtest.cc:2674
    #6 0x5586e11fab16 in testing::TestInfo::Run() valijson/thirdparty/googletest/googletest/src/gtest.cc:2853
    #7 0x5586e11fbd30 in testing::TestSuite::Run() valijson/thirdparty/googletest/googletest/src/gtest.cc:3012
    #8 0x5586e12224dc in testing::internal::UnitTestImpl::RunAllTests() valijson/thirdparty/googletest/googletest/src/gtest.cc:5870
    #9 0x5586e125e471 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) valijson/thirdparty/googletest/googletest/src/gtest.cc:2599
    #10 0x5586e124cea9 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) valijson/thirdparty/googletest/googletest/src/gtest.cc:2635
    #11 0x5586e121ec62 in testing::UnitTest::Run() valijson/thirdparty/googletest/googletest/src/gtest.cc:5444
    #12 0x5586e128687b in RUN_ALL_TESTS() valijson/thirdparty/googletest/googletest/include/gtest/gtest.h:2293
    #13 0x5586e1286744 in main valijson/thirdparty/googletest/googletest/src/gtest_main.cc:51
    #14 0x7f47fd08dd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #15 0x7f47fd08de3f in __libc_start_main_impl ../csu/libc-start.c:392
    #16 0x5586e0e02074 in _start (valijson/build/Desktop/Debug/test_suite+0xa1074)

0x5586e133a5e4 is located 12 bytes to the right of global variable 'offsetsFromUTF8' defined in 'valijson/include/valijson/utils/utf8_utils.hpp:17:23' (0x5586e133a5c0) of size 24
SUMMARY: AddressSanitizer: global-buffer-overflow valijson/include/valijson/utils/utf8_utils.hpp:38 in valijson::utils::u8_nextchar(char const*, unsigned long*)
Shadow bytes around the buggy address:
  0x0ab15c25f460: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab15c25f470: 00 00 00 00 06 f9 f9 f9 f9 f9 f9 f9 00 00 00 03
  0x0ab15c25f480: f9 f9 f9 f9 00 00 00 00 05 f9 f9 f9 f9 f9 f9 f9
  0x0ab15c25f490: 00 00 00 00 06 f9 f9 f9 f9 f9 f9 f9 05 f9 f9 f9
  0x0ab15c25f4a0: f9 f9 f9 f9 06 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
=>0x0ab15c25f4b0: 00 00 00 00 00 00 00 00 00 00 00 f9[f9]f9 f9 f9
  0x0ab15c25f4c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab15c25f4d0: 01 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0ab15c25f4e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ab15c25f4f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 07 f9
  0x0ab15c25f500: f9 f9 f9 f9 00 04 f9 f9 f9 f9 f9 f9 00 00 00 01
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==1789377==ABORTING
```