### PR TITLE
Prevent potential division by zero

### DIFF
--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -19,6 +19,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include <valijson/constraints/basic_constraint.hpp>
 #include <valijson/internal/custom_allocator.hpp>
@@ -784,6 +785,11 @@ public:
 
     void setDivisor(double newValue)
     {
+        if (!std::isfinite(newValue) || newValue <= 0.0) {
+            throwRuntimeError(
+                "Divisor for 'multipleOf' or 'divisibleBy' must be positive");
+        }
+
         m_value = newValue;
     }
 
@@ -813,6 +819,11 @@ public:
 
     void setDivisor(int64_t newValue)
     {
+        if (newValue <= 0) {
+            throwRuntimeError(
+                "Divisor for 'multipleOf' or 'divisibleBy' must be positive");
+        }
+
         m_value = newValue;
     }
 


### PR DESCRIPTION
This patch fixes division by zero for schemas that contain zero value for 'multipleOf' or 'divisibleBy'. Yes, this is not legal but it's better to fail with a human-friendly error. Address sanitizer report:

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==1864334==ERROR: AddressSanitizer: FPE on unknown address 0x564b7fe3bda9 (pc 0x564b7fe3bda9 bp 0x7ffde7afcac0 sp 0x7ffde7afc8d0 T0)
    #0 0x564b7fe3bda9 in valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>::visit(valijson::constraints::MultipleOfIntConstraint const&) valijson/include/valijson/validation_visitor.hpp:848
    #1 0x564b7fe44332 in valijson::constraints::BasicConstraint<valijson::constraints::MultipleOfIntConstraint>::accept(valijson::constraints::ConstraintVisitor&) const valijson/include/valijson/constraints/basic_constraint.hpp:36
    #2 0x564b7fdae3ae in valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>::validationCallback(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&) valijson/include/valijson/validation_visitor.hpp:1847
    #3 0x564b7fe07718 in bool std::__invoke_impl<bool, bool (*&)(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&), valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&>(std::__invoke_other, bool (*&)(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&), valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&) /usr/include/c++/11/bits/invoke.h:61
    #4 0x564b7fdfa032 in std::__invoke_result<bool (*&)(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&), valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&>::type std::__invoke<bool (*&)(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&), valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&>(bool (*&)(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&), valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&) /usr/include/c++/11/bits/invoke.h:96
    #5 0x564b7fdec953 in bool std::_Bind<bool (*(std::_Placeholder<1>, std::reference_wrapper<valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine> >))(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&)>::__call<bool, valijson::constraints::Constraint const&, 0ul, 1ul>(std::tuple<valijson::constraints::Constraint const&>&&, std::_Index_tuple<0ul, 1ul>) /usr/include/c++/11/functional:420
    #6 0x564b7fde0d37 in bool std::_Bind<bool (*(std::_Placeholder<1>, std::reference_wrapper<valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine> >))(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&)>::operator()<valijson::constraints::Constraint const&, bool>(valijson::constraints::Constraint const&) /usr/include/c++/11/functional:503
    #7 0x30124d9f8326dfff
    #8 0x564b7fdd1356 in std::enable_if<std::__and_<std::__not_<std::is_void<bool> >, std::is_convertible<std::__invoke_result<std::_Bind<bool (*(std::_Placeholder<1>, std::reference_wrapper<valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine> >))(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&)>&, valijson::constraints::Constraint const&>::type, bool> >::value, bool>::type std::__invoke_r<bool, std::_Bind<bool (*(std::_Placeholder<1>, std::reference_wrapper<valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine> >))(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&)>&, valijson::constraints::Constraint const&>(std::_Bind<bool (*(std::_Placeholder<1>, std::reference_wrapper<valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine> >))(valijson::constraints::Constraint const&, valijson::ValidationVisitor<valijson::adapters::GenericRapidJsonAdapter<rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> > >, valijson::DefaultRegexEngine>&)>&, valijson::constraints::Constraint const&) /usr/include/c++/11/bits/invoke.h:142
    #9 0x7ff000000000
    #10 0x7ff016bdb6ef

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: FPE (<unknown module>) 
```