### PR TITLE
Fuzzing improvements

### DIFF
--- a/tests/fuzzing/oss-fuzz-build.sh
+++ b/tests/fuzzing/oss-fuzz-build.sh
@@ -2,38 +2,31 @@
 
 git submodule update --init --depth 1 thirdparty
 
-# This line causes an abort which breaks fuzzing:
-sed -i '27d' include/valijson/utils/rapidjson_utils.hpp
-
 mkdir build
 cd build
 cmake \
-  -Dvalijson_BUILD_TESTS=TRUE \
+  -Dvalijson_BUILD_TESTS=FALSE \
   -Dvalijson_BUILD_EXAMPLES=FALSE \
-	-Dvalijson_EXCLUDE_BOOST=TRUE \
-	..
+  -Dvalijson_EXCLUDE_BOOST=TRUE \
+  ..
 
 make -j"$(nproc)"
 
 cd ../tests/fuzzing
 
-find ../.. -name "*.o" -exec ar rcs fuzz_lib.a {} \;
-
 # CXXFLAGS may contain spaces
 # shellcheck disable=SC2086
-"$CXX" $CXXFLAGS -DVALIJSON_USE_EXCEPTIONS=1 \
-	-I/src/valijson/thirdparty/rapidjson/include \
-	-I/src/valijson/thirdparty/rapidjson/include/rapidjson \
-	-I/src/valijson/include \
-	-I/src/valijson/include/valijson \
-	-I/src/valijson/include/valijson/adapters \
-	-c fuzzer.cpp -o fuzzer.o
-
-# shellcheck disable=SC2086
 "$CXX" $CXXFLAGS "$LIB_FUZZING_ENGINE" \
-	-DVALIJSON_USE_EXCEPTIONS=1 \
-	-rdynamic fuzzer.o \
-	-o "${OUT}/fuzzer" fuzz_lib.a
+    -DVALIJSON_USE_EXCEPTIONS=1 \
+	-I/src/valijson/thirdparty/rapidjson/include \
+	-I/src/valijson/include \
+	fuzzer.cpp -o "${OUT}/fuzzer"
 
-zip "${OUT}/fuzzer_seed_corpus.zip" \
-	"${SRC}/valijson/doc/schema/draft-03.json"
+mkdir seed_corpus
+
+find "${SRC}/valijson/thirdparty/JSON-Schema-Test-Suite/tests" -name "*.json" | while read file; do
+    sha1=$(sha1sum "$file" | awk '{print $1}')
+    cp "$file" seed_corpus/"${sha1}"
+done
+
+zip -j -r "${OUT}/fuzzer_seed_corpus.zip" seed_corpus


### PR DESCRIPTION
Major improvements:

- the fuzzer performs not only schema parsing but validation too (the most interesting part of the library)
- the fuzzer performs parsing in-memory avoiding temporary files which improves fuzzing speed
- seed corpus is based on `JSON-Schema-Test-Suite/tests` files

Minor improvements:

- avoid `return 1` from fuzz target in case of exceptions - it makes fuzzing slower
- the line `sed -i '27d' include/valijson/utils/rapidjson_utils.hpp` was removed from tests/fuzzing/oss-fuzz-build.sh. A proper change is applied to the fuzzing test instead
- compile fuzzer with `-Dvalijson_BUILD_TESTS=FALSE` (there is no sense in compiling unit tests for fuzzing)
- added `-j` argument to zip to build a flat list of files (subdirectories are not consumed by the fuzzer)

List of issues found by new approach: https://github.com/tristanpenman/valijson/pull/197 https://github.com/tristanpenman/valijson/pull/198 https://github.com/tristanpenman/valijson/pull/199 https://github.com/tristanpenman/valijson/issues/200