### PR TITLE
bundle: Add `schema_cache.hpp' to bundle script

### DIFF
--- a/bundle.sh
+++ b/bundle.sh
@@ -79,6 +79,7 @@ common_headers=(
   include/valijson/utils/utf8_utils.hpp
   include/valijson/constraints/constraint.hpp
   include/valijson/subschema.hpp
+  include/valijson/schema_cache.hpp
   include/valijson/schema.hpp
   include/valijson/constraints/constraint_visitor.hpp
   include/valijson/constraints/basic_constraint.hpp


### PR DESCRIPTION
    bundle: Add `schema_cache.hpp' to bundle script
    
    `bundle.sh' script generates a header file with missing `SchemaCache`
    declaration.  So, this patch fix it.
    
    valijsonQtjson.h:5746:46: error: ‘SchemaCache’ has not been declared
     5746 |     static const Subschema *querySchemaCache(SchemaCache &schemaCache,
          |                                              ^~~~~~~~~~~
    valijsonQtjson.h:5769:35: error: ‘SchemaCache’ has not been declared
     5769 |     static void updateSchemaCache(SchemaCache &schemaCache,
          |                                   ^~~~~~~~~~~
    valijsonQtjson.h:5822:9: error: ‘SchemaCache’ has not been declared
     5822 |         SchemaCache &schemaCache, std::vector<std::string> &newCacheKeys)
    
          * bundle.sh(common_headers): Add new `schema_cache.hpp' entry.
    
    Signed-off-by: Guillermo E. Martinez <martinez.enrique@autozone.com
