### PR TITLE
Enable using boost::regex instead of std::regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ option(valijson_BUILD_TESTS "Build valijson test suite." FALSE)
 option(valijson_EXCLUDE_BOOST "Exclude Boost when building test suite." FALSE)
 option(valijson_USE_EXCEPTIONS "Use exceptions in valijson and included libs." TRUE)
 
+option(valijson_USE_BOOST_REGEX "Use boost::regex instead of std::regex internally." FALSE)
+mark_as_advanced(valijson_USE_BOOST_REGEX)
+
 if(MSVC)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
 else()
@@ -45,6 +48,9 @@ target_include_directories(valijson INTERFACE
 
 if(valijson_USE_EXCEPTIONS)
     target_compile_definitions(valijson INTERFACE -DVALIJSON_USE_EXCEPTIONS=1)
+endif()
+if (valijson_USE_BOOST_REGEX)
+    target_compile_definitions(valijson INTERFACE -DVALIJSON_USE_BOOST_REGEX=1)
 endif()
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Then to use it, you must define a customer validator type:
 
 Once you've done this, `MyValidator` can be used in place of the default `valijson::Validator` type.
 
+Alternatively the library can be instructed to use `boost::regex` by specifying either `valijson_USE_BOOST_REGEX=TRUE` in CMake or defining `VALIJSON_USE_BOOST_REGEX=1` as a `#define` before including any valijson headers. Note that the library does not source `boost::regex` for you when specifying this option- it is assumed you have it already.
+
 ## Memory Management
 
 Valijson has been designed to safely manage, and eventually free, the memory that is allocated while parsing a schema or validating a document. When working with an externally loaded schema (i.e. one that is populated using the `SchemaParser` class) you can rely on RAII semantics.

--- a/include/valijson/internal/regex.hpp
+++ b/include/valijson/internal/regex.hpp
@@ -1,0 +1,27 @@
+#if defined(VALIJSON_USE_BOOST_REGEX) && VALIJSON_USE_BOOST_REGEX
+
+#include <boost/regex.hpp>
+
+namespace valijson {
+namespace internal {
+using boost::regex;
+using boost::regex_match;
+using boost::regex_search;
+using boost::smatch;
+} // namespace internal
+} // namespace valijson
+
+#else
+
+#include <regex>
+
+namespace valijson {
+namespace internal {
+using std::regex;
+using std::regex_match;
+using std::regex_search;
+using std::smatch;
+} // namespace internal
+} // namespace valijson
+
+#endif

--- a/include/valijson/internal/uri.hpp
+++ b/include/valijson/internal/uri.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <regex>
 #include <string>
+
+#include <valijson/internal/regex.hpp>
 
 namespace valijson {
 namespace internal {
@@ -25,10 +26,10 @@ inline bool isUriAbsolute(const std::string &documentUri)
  * This function validates that the URI matches the RFC 8141 spec
  */
 inline bool isUrn(const std::string &documentUri) {
-  static const std::regex pattern(
+  static const internal::regex pattern(
       "^((urn)|(URN)):(?!urn:)([a-zA-Z0-9][a-zA-Z0-9-]{1,31})(:[-a-zA-Z0-9\\\\._~%!$&'()\\/*+,;=]+)+(\\?[-a-zA-Z0-9\\\\._~%!$&'()\\/*+,;:=]+){0,1}(#[-a-zA-Z0-9\\\\._~%!$&'()\\/*+,;:=]+){0,1}$");
 
-  return std::regex_match(documentUri, pattern);
+  return internal::regex_match(documentUri, pattern);
 }
 
 /**

--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -2,10 +2,10 @@
 
 #include <cmath>
 #include <string>
-#include <regex>
 #include <unordered_map>
 #include <utility>
 
+#include <valijson/internal/regex.hpp>
 #include <valijson/adapters/std_string_adapter.hpp>
 #include <valijson/constraints/concrete_constraints.hpp>
 #include <valijson/constraints/constraint_visitor.hpp>
@@ -383,9 +383,9 @@ public:
         const std::string format = constraint.getFormat();
         if (format == "date") {
             // Matches dates like: 2022-07-18
-            static const std::regex date_regex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$");
-            std::smatch matches;
-            if (std::regex_match(s, matches, date_regex)) {
+            static const internal::regex date_regex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$");
+            internal::smatch matches;
+            if (internal::regex_match(s, matches, date_regex)) {
                 const auto month = std::stoi(matches[2].str());
                 const auto day = std::stoi(matches[3].str());
                 return validate_date_range(month, day);
@@ -399,9 +399,9 @@ public:
         } else if (format == "time") {
             // Strict mode matches times like: 16:52:45Z, 16:52:45+02:00
             // Permissive mode also matches date/times like 16:52:45
-            static const std::regex strictRegex("^([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
-            static const std::regex permissiveRegex("^([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])?|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
-            if (std::regex_match(s, m_strictDateTime ? strictRegex : permissiveRegex)) {
+            static const internal::regex strictRegex("^([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
+            static const internal::regex permissiveRegex("^([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])?|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
+            if (internal::regex_match(s, m_strictDateTime ? strictRegex : permissiveRegex)) {
                 return true;
             } else {
                 if (m_results) {
@@ -413,10 +413,10 @@ public:
         } else if (format == "date-time") {
             // Strict mode matches date/times like: 2022-07-18T16:52:45Z, 2022-07-18T16:52:45+02:00
             // Permissive mode also matches date/times like: 2022-07-18T16:52:45
-            static const std::regex strictRegex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
-            static const std::regex permissiveRegex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])?|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
-            std::smatch matches;
-            if (std::regex_match(s, matches, m_strictDateTime ? strictRegex : permissiveRegex)) {
+            static const internal::regex strictRegex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
+            static const internal::regex permissiveRegex("^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])?|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$");
+            internal::smatch matches;
+            if (internal::regex_match(s, matches, m_strictDateTime ? strictRegex : permissiveRegex)) {
                 const auto month = std::stoi(matches[2].str());
                 const auto day = std::stoi(matches[3].str());
                 return validate_date_range(month, day);
@@ -1602,7 +1602,7 @@ private:
             const std::string patternPropertyStr(patternProperty.c_str());
 
             // It would be nice to store pre-allocated regex objects in the
-            // PropertiesConstraint. does std::regex currently support
+            // PropertiesConstraint. does internal::regex currently support
             // custom allocators? Anyway, this isn't an issue here, because Valijson's
             // JSON Scheme validator does not yet support custom allocators.
             auto it = m_regexesCache.find(patternPropertyStr);

--- a/include/valijson/validator.hpp
+++ b/include/valijson/validator.hpp
@@ -106,11 +106,11 @@ struct DefaultRegexEngine
 
     static bool search(const std::string& s, const DefaultRegexEngine& r)
     {
-        return std::regex_search(s, r.regex);
+        return internal::regex_search(s, r.regex);
     }
 
 private:
-    std::regex regex;
+    internal::regex regex;
 };
 
 using Validator = ValidatorT<DefaultRegexEngine>;


### PR DESCRIPTION
Adds an opt-in switch to enable the use of `boost::regex` instead of its generally-much-worse baby brother `std::regex`. Closes #212.