### PR TITLE
Update bundle.sh to include regex.hpp

### DIFF
--- a/bundle.sh
+++ b/bundle.sh
@@ -74,6 +74,7 @@ common_headers=(
   include/valijson/internal/frozen_value.hpp
   include/valijson/internal/json_pointer.hpp
   include/valijson/internal/json_reference.hpp
+  include/valijson/internal/regex.hpp
   include/valijson/internal/uri.hpp
   include/valijson/utils/file_utils.hpp
   include/valijson/utils/utf8_utils.hpp


### PR DESCRIPTION
When I use the bundle.sh script to create a bundled header file, I get compiler errors when using this header file: 
```
valijson_std_string_bundled.hpp(2960,26): error C2039: 'regex': is not a member of 'valijson::internal'
```

The problem is that the using-declarations in `regex.hpp` are not bundled into the header. The fix is to include `regex.hpp` in this script so it is bundled into the header.