### PR TITLE
build tests in oss-fuzz build

### DIFF
--- a/tests/fuzzing/oss-fuzz-build.sh
+++ b/tests/fuzzing/oss-fuzz-build.sh
@@ -5,7 +5,7 @@ git submodule update --init --depth 1 thirdparty
 mkdir build
 cd build
 cmake \
-  -Dvalijson_BUILD_TESTS=FALSE \
+  -Dvalijson_BUILD_TESTS=TRUE \
   -Dvalijson_BUILD_EXAMPLES=FALSE \
   -Dvalijson_EXCLUDE_BOOST=TRUE \
   ..


### PR DESCRIPTION
I changed the OSS-Fuzz build script in https://github.com/google/oss-fuzz/pull/13605 to add support for Chronos. Propagating the changes here to remove the `.diff` in OSS-Fuzz.