### PR TITLE
count embedded null bytes in u8_strlen for length validation

### DIFF
--- a/include/valijson/utils/utf8_utils.hpp
+++ b/include/valijson/utils/utf8_utils.hpp
@@ -48,5 +48,39 @@ inline uint64_t u8_strlen(const char *s)
     return count;
 }
 
+/* number of characters in a buffer of the given byte length; unlike the
+   variant above, this does not stop at an embedded null byte */
+inline uint64_t u8_strlen(const char *s, size_t length)
+{
+    uint64_t count = 0;
+    size_t pos = 0;
+
+    while (pos < length) {
+        unsigned char p = static_cast<unsigned char>(s[pos]);
+
+        size_t seqLen = p < 0x80   ? 1  // 0xxxxxxx: 1-byte (ASCII)
+                        : p < 0xE0 ? 2  // 110xxxxx: 2-byte sequence
+                        : p < 0xF0 ? 3  // 1110xxxx: 3-byte sequence
+                        : p < 0xF8 ? 4  // 11110xxx: 4-byte sequence
+                                   : 1; // treat as a single character
+
+        if (seqLen > length - pos) {
+            seqLen = length - pos;
+        }
+
+        for (size_t i = 1; i < seqLen; ++i) {
+            if (isutf(s[pos + i])) {
+                seqLen = i;
+                break;
+            }
+        }
+
+        pos += seqLen;
+        count++;
+    }
+
+    return count;
+}
+
 } // namespace utils
 } // namespace valijson

--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -613,7 +613,7 @@ public:
         }
 
         const std::string s = m_target.asString();
-        const uint64_t len = utils::u8_strlen(s.c_str());
+        const uint64_t len = utils::u8_strlen(s.c_str(), s.size());
         const uint64_t maxLength = constraint.getMaxLength();
         if (len <= maxLength) {
             return true;
@@ -729,7 +729,7 @@ public:
         }
 
         const std::string s = m_target.asString();
-        const uint64_t len = utils::u8_strlen(s.c_str());
+        const uint64_t len = utils::u8_strlen(s.c_str(), s.size());
         const uint64_t minLength = constraint.getMinLength();
         if (len >= minLength) {
             return true;


### PR DESCRIPTION
u8_strlen in utf8_utils.hpp stops at the first null byte, so maxLength/minLength miscount JSON string values containing an embedded  and an over-length string can slip past maxLength. Add a length-aware overload and call it from the two length visitors with s.size().
