### PR TITLE
guard against int64_t overflow in multipleOf integer check

### DIFF
--- a/include/valijson/validation_visitor.hpp
+++ b/include/valijson/validation_visitor.hpp
@@ -847,6 +847,19 @@ public:
                 }
                 return false;
             }
+            // Casting a double outside the range of int64_t is undefined
+            // behaviour, so check those values in floating point instead.
+            if (d < static_cast<double>(std::numeric_limits<int64_t>::min()) ||
+                    d > static_cast<double>(std::numeric_limits<int64_t>::max())) {
+                if (fabs(remainder(d, static_cast<double>(divisor))) >
+                        std::numeric_limits<double>::epsilon()) {
+                    if (m_results) {
+                        m_results->pushError(m_path, "Value should be a multiple of " + std::to_string(divisor));
+                    }
+                    return false;
+                }
+                return true;
+            }
             i = static_cast<int64_t>(d);
         } else {
             return true;


### PR DESCRIPTION
validation_visitor.hpp:850 casts a JSON number straight to int64_t for the integer multipleOf check, which is undefined behaviour when the value is outside the int64_t range (e.g. 1e308 against {"multipleOf": 3}); UBSan flags it on that line. Range-check the value first and fall back to a floating-point remainder for out-of-range numbers.