### PR TITLE
Provide alternatives to std::from_char

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -61,12 +61,19 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update --yes
-        sudo apt install --yes libboost-all-dev qtbase5-dev libcurlpp-dev libcurl4-openssl-dev ${{ matrix.compiler.package }}
+        sudo apt install --yes \
+          libboost-all-dev \
+          libboost-json-dev \
+          libpoco-dev \
+          qtbase5-dev \
+          libcurlpp-dev \
+          libcurl4-openssl-dev \
+          ${{ matrix.compiler.package }}
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dvalijson_BUILD_TESTS=ON -Dvalijson_BUILD_EXAMPLES=ON -Dvalijson_USE_FAST_FLOAT=${{matrix.compiler.fast_float}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dvalijson_BUILD_TESTS=ON -Dvalijson_BUILD_EXAMPLES=ON -Dvalijson_REQUIRE_ALL_ADAPTER_TESTS=ON -Dvalijson_USE_FAST_FLOAT=${{matrix.compiler.fast_float}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,20 +12,47 @@ env:
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.compiler.name }})
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        compiler:
+          - name: GCC
+            cc: gcc
+            cxx: g++
+            package: ''
+            repository: ''
+          - name: LLVM 19
+            cc: clang-19
+            cxx: clang++-19
+            package: clang-19
+            repository: ''
+          - name: LLVM 22
+            cc: clang-22
+            cxx: clang++-22
+            package: clang-22
+            repository: llvm-toolchain-noble-22
+
+    env:
+      CC: ${{ matrix.compiler.cc }}
+      CXX: ${{ matrix.compiler.cxx }}
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
+    - name: Add LLVM package repository
+      if: matrix.compiler.repository != ''
+      run: |
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+        echo "deb https://apt.llvm.org/noble/ ${{ matrix.compiler.repository }} main" | sudo tee /etc/apt/sources.list.d/apt.llvm.org.list
+
     - name: Install dependencies
       run: |
         sudo apt update --yes
-        sudo apt install --yes libboost-all-dev qtbase5-dev libcurlpp-dev libcurl4-openssl-dev
+        sudo apt install --yes libboost-all-dev qtbase5-dev libcurlpp-dev libcurl4-openssl-dev ${{ matrix.compiler.package }}
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,16 +23,25 @@ jobs:
             cxx: g++
             package: ''
             repository: ''
-          - name: LLVM 19
+            fast_float: OFF
+          - name: LLVM 19 (fast_float)
             cc: clang-19
             cxx: clang++-19
             package: clang-19
             repository: ''
+            fast_float: ON
+          - name: LLVM 19 (istringstream)
+            cc: clang-19
+            cxx: clang++-19
+            package: clang-19
+            repository: ''
+            fast_float: OFF
           - name: LLVM 22
             cc: clang-22
             cxx: clang++-22
             package: clang-22
             repository: llvm-toolchain-noble-22
+            fast_float: OFF
 
     env:
       CC: ${{ matrix.compiler.cc }}
@@ -57,7 +66,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dvalijson_BUILD_TESTS=ON -Dvalijson_BUILD_EXAMPLES=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -Dvalijson_BUILD_TESTS=ON -Dvalijson_BUILD_EXAMPLES=ON -Dvalijson_USE_FAST_FLOAT=${{matrix.compiler.fast_float}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 	path = thirdparty/JSON-Schema-Test-Suite
 	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite.git
 	shallow = true
+[submodule "thirdparty/fast_float"]
+	path = thirdparty/fast_float
+	url = https://github.com/fastfloat/fast_float.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(valijson_BUILD_EXAMPLES "Build valijson examples." FALSE)
 option(valijson_BUILD_TESTS "Build valijson test suite." FALSE)
 option(valijson_EXCLUDE_BOOST "Exclude Boost when building test suite." FALSE)
+option(valijson_USE_FAST_FLOAT "Use the vendored fast_float library for string-to-double conversions." FALSE)
 option(valijson_USE_EXCEPTIONS "Use exceptions in valijson and included libs." TRUE)
 
 option(valijson_USE_BOOST_REGEX "Use boost::regex instead of std::regex internally." FALSE)
@@ -39,6 +40,14 @@ target_include_directories(valijson INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+if(valijson_USE_FAST_FLOAT)
+    target_include_directories(valijson INTERFACE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/fast_float/include>)
+    target_compile_definitions(valijson INTERFACE
+            VALIJSON_HAS_FAST_FLOAT_FROM_CHARS=1
+            VALIJSON_HAS_STD_FROM_CHARS=0)
+endif()
+
 if(valijson_USE_EXCEPTIONS)
     target_compile_definitions(valijson INTERFACE -DVALIJSON_USE_EXCEPTIONS=1)
 endif()
@@ -47,6 +56,10 @@ if (valijson_USE_BOOST_REGEX)
 endif()
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(valijson_USE_FAST_FLOAT)
+    install(DIRECTORY thirdparty/fast_float/include/
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 install(TARGETS valijson
     EXPORT valijsonConfig
@@ -59,6 +72,13 @@ install(EXPORT valijsonConfig
 
 if(NOT valijson_BUILD_TESTS AND NOT valijson_BUILD_EXAMPLES)
     return()
+endif()
+
+if(valijson_USE_FAST_FLOAT)
+    include_directories(SYSTEM thirdparty/fast_float/include)
+    add_compile_definitions(
+            VALIJSON_HAS_FAST_FLOAT_FROM_CHARS=1
+            VALIJSON_HAS_STD_FROM_CHARS=0)
 endif()
 
 if(valijson_USE_EXCEPTIONS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ if(valijson_BUILD_TESTS)
     set(TEST_SOURCES
         tests/test_adapter_comparison.cpp
         tests/test_date_time_format.cpp
+        tests/test_double_parser.cpp
         tests/test_fetch_absolute_uri_document_callback.cpp
         tests/test_fetch_urn_document_callback.cpp
         tests/test_json_pointer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(valijson_BUILD_EXAMPLES "Build valijson examples." FALSE)
 option(valijson_BUILD_TESTS "Build valijson test suite." FALSE)
 option(valijson_EXCLUDE_BOOST "Exclude Boost when building test suite." FALSE)
+option(valijson_REQUIRE_ALL_ADAPTER_TESTS "Fail configuration when optional adapter test dependencies are unavailable." FALSE)
 option(valijson_USE_FAST_FLOAT "Use the vendored fast_float library for string-to-double conversions." FALSE)
 option(valijson_USE_EXCEPTIONS "Use exceptions in valijson and included libs." TRUE)
 
@@ -191,12 +192,18 @@ if(valijson_BUILD_TESTS)
         check_include_file_cxx("boost/json.hpp" BOOST_JSON_HPP_FOUND)
         if(${BOOST_JSON_HPP_FOUND})
             list(APPEND TEST_SOURCES tests/test_boost_json_adapter.cpp)
+        elseif(valijson_REQUIRE_ALL_ADAPTER_TESTS)
+            message(FATAL_ERROR
+                "Boost.JSON is required when valijson_REQUIRE_ALL_ADAPTER_TESTS is enabled.")
         else()
             message(WARNING
                 "boost/json.hpp not found; tests for boost_json_adapter will not be built. "
                 "If you have recently upgraded Boost to 1.75.0 or later, you may need to clear "
                 "your CMake cache for the header to be found.")
         endif()
+    elseif(valijson_REQUIRE_ALL_ADAPTER_TESTS)
+        message(FATAL_ERROR
+            "Boost is required when valijson_REQUIRE_ALL_ADAPTER_TESTS is enabled.")
     endif()
 
     if(Poco_FOUND)
@@ -204,11 +211,17 @@ if(valijson_BUILD_TESTS)
         list(APPEND TEST_LIBS
             Poco::Foundation
             Poco::JSON)
+    elseif(valijson_REQUIRE_ALL_ADAPTER_TESTS)
+        message(FATAL_ERROR
+            "Poco Foundation and JSON are required when valijson_REQUIRE_ALL_ADAPTER_TESTS is enabled.")
     endif()
 
     if(valijson_QT_CORE_TARGET)
         list(APPEND TEST_LIBS ${valijson_QT_CORE_TARGET})
         list(APPEND TEST_SOURCES tests/test_qtjson_adapter.cpp)
+    elseif(valijson_REQUIRE_ALL_ADAPTER_TESTS)
+        message(FATAL_ERROR
+            "Qt Core is required when valijson_REQUIRE_ALL_ADAPTER_TESTS is enabled.")
     endif()
 
     # Unit tests executable

--- a/cmake/Findcurlpp.cmake
+++ b/cmake/Findcurlpp.cmake
@@ -1,4 +1,4 @@
-include(FindPkgConfig)
+find_package(PkgConfig REQUIRED)
 include(FindPackageHandleStandardArgs)
 
 pkg_check_modules(curlpp_PKGCONF REQUIRED curlpp)

--- a/include/valijson/adapters/std_string_adapter.hpp
+++ b/include/valijson/adapters/std_string_adapter.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <charconv>
 #include <string>
 
 #include <valijson/internal/adapter.hpp>
 #include <valijson/internal/frozen_value.hpp>
 #include <valijson/internal/basic_adapter.hpp>
+#include <valijson/internal/double_parser.hpp>
 #include <valijson/exceptions.hpp>
 
 namespace valijson {
@@ -315,11 +315,8 @@ public:
 
     bool maybeDouble() const override
     {
-        const char *b = m_value.data();
-        const char *end = b + m_value.length();
         double x;
-        auto [ptr, ec] = std::from_chars(b, end, x);
-        return ec == std::errc() && ptr == end;
+        return internal::parseDouble(m_value, x);
     }
 
     bool maybeInteger() const override

--- a/include/valijson/internal/basic_adapter.hpp
+++ b/include/valijson/internal/basic_adapter.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <charconv>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -8,6 +7,7 @@
 #include <sstream>
 
 #include <valijson/internal/adapter.hpp>
+#include <valijson/internal/double_parser.hpp>
 #include <valijson/exceptions.hpp>
 
 namespace valijson {
@@ -375,11 +375,8 @@ public:
         } else if (m_value.isString()) {
             std::string s;
             if (m_value.getString(s)) {
-                const char *b = s.data();
-                const char *end = b + s.length();
                 double x;
-                auto [ptr, ec] = std::from_chars(b, end, x);
-                if (ec != std::errc() || ptr != end) {
+                if (!internal::parseDouble(s, x)) {
                     return false;
                 }
                 result = x;
@@ -799,11 +796,8 @@ public:
         } else if (maybeString()) {
             std::string s;
             if (m_value.getString(s)) {
-                const char *b = s.data();
-                const char *end = b + s.length();
                 double x;
-                auto [ptr, ec] = std::from_chars(b, end, x);
-                return ec == std::errc() && ptr == end;
+                return internal::parseDouble(s, x);
             }
         }
 

--- a/include/valijson/internal/double_parser.hpp
+++ b/include/valijson/internal/double_parser.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <locale>
+#include <sstream>
+#include <string>
+
+// This file provides alternative implementations for converting strings to
+// double values. This addresses the fact that std::from_chars is not
+// available in all standard libraries, and that some implementations of
+// std::from_chars do not support floating-point types.
+//
+// We support three different implementations:
+//
+// 1. std::from_chars (C++17) - preferred if available, as indicated by
+//                              the VALIJSON_HAS_STD_FROM_CHARS or compiler-
+//                              specific preprocessor defines
+//
+// 2. fast_float::from_chars  - if VALIJSON_HAS_FAST_FLOAT_FROM_CHARS is
+//                              defined, then we will use the fast_float
+//                              library's implementation of from_chars
+//
+// 3. std::istringstream      - fallback if neither of the above are available
+//
+
+// attempt detection of std::from_chars support
+#ifndef VALIJSON_HAS_STD_FROM_CHARS
+#  if defined(_MSC_VER) && _MSC_VER >= 1915
+#    define VALIJSON_HAS_STD_FROM_CHARS 1
+#  elif defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 200000
+#    define VALIJSON_HAS_STD_FROM_CHARS 1
+#  elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 11
+#    define VALIJSON_HAS_STD_FROM_CHARS 1
+#  else
+#    define VALIJSON_HAS_STD_FROM_CHARS 0
+#  endif
+#endif
+
+// include the appropriate header for the available implementation
+#if VALIJSON_HAS_STD_FROM_CHARS
+#  include <charconv>
+#elif defined(VALIJSON_HAS_FAST_FLOAT_FROM_CHARS)
+#  include <fast_float/fast_float.h>
+#endif
+
+namespace valijson {
+namespace internal {
+
+inline bool parseDouble(const std::string &input, double &result)
+{
+#if VALIJSON_HAS_STD_FROM_CHARS
+    const char *begin = input.data();
+    const char *end = begin + input.length();
+    double value;
+    const auto conversion = std::from_chars(begin, end, value);
+    if (conversion.ec != std::errc() || conversion.ptr != end) {
+        return false;
+    }
+#elif defined(VALIJSON_HAS_FAST_FLOAT_FROM_CHARS)
+    const char *begin = input.data();
+    const char *end = begin + input.length();
+    double value;
+    const auto conversion = fast_float::from_chars(begin, end, value);
+    if (conversion.ec != std::errc() || conversion.ptr != end) {
+        return false;
+    }
+#else
+    std::istringstream stream(input);
+    stream.imbue(std::locale::classic());
+    stream >> std::noskipws;
+
+    double value;
+    if (!(stream >> value) || stream.peek() != std::char_traits<char>::eof()) {
+        return false;
+    }
+#endif
+
+    result = value;
+    return true;
+}
+
+} // namespace internal
+} // namespace valijson

--- a/tests/test_double_parser.cpp
+++ b/tests/test_double_parser.cpp
@@ -1,0 +1,57 @@
+#include <locale>
+
+#include <gtest/gtest.h>
+
+#include <valijson/internal/double_parser.hpp>
+
+namespace {
+
+class CommaDecimalPoint: public std::numpunct<char>
+{
+protected:
+    char do_decimal_point() const override
+    {
+        return ',';
+    }
+};
+
+class GlobalLocaleGuard
+{
+public:
+    explicit GlobalLocaleGuard(const std::locale &locale)
+      : previous(std::locale::global(locale)) { }
+
+    ~GlobalLocaleGuard()
+    {
+        std::locale::global(previous);
+    }
+
+private:
+    const std::locale previous;
+};
+
+} // namespace
+
+TEST(DoubleParser, ParsesCompleteFloatingPointStrings)
+{
+    double result = 0.0;
+    EXPECT_TRUE(valijson::internal::parseDouble("-12.5e2", result));
+    EXPECT_DOUBLE_EQ(-1250.0, result);
+
+    EXPECT_FALSE(valijson::internal::parseDouble("", result));
+    EXPECT_FALSE(valijson::internal::parseDouble("1.5suffix", result));
+    EXPECT_FALSE(valijson::internal::parseDouble(" 1.5", result));
+    EXPECT_FALSE(valijson::internal::parseDouble("1.5 ", result));
+}
+
+TEST(DoubleParser, IsIndependentOfGlobalLocale)
+{
+    const std::locale commaLocale(
+            std::locale::classic(), new CommaDecimalPoint);
+    const GlobalLocaleGuard guard(commaLocale);
+
+    double result = 0.0;
+    EXPECT_TRUE(valijson::internal::parseDouble("1.5", result));
+    EXPECT_DOUBLE_EQ(1.5, result);
+    EXPECT_FALSE(valijson::internal::parseDouble("1,5", result));
+}


### PR DESCRIPTION
This branch provides alternative implementations for converting strings to double values. This addresses the fact that `std::from_chars` is not available in all standard libraries, and that some implementations of `std::from_chars` do not support floating-point types.

We support three different implementations:

1. `std::from_chars` (C++17) - preferred if available, as indicated by the `VALIJSON_HAS_STD_FROM_CHARS` or compiler-specific preprocessor defines
2. `fast_float::from_chars` - if `VALIJSON_HAS_FAST_FLOAT_FROM_CHARS` is defined, then we will use the fast_float library's implementation of `from_chars`
3. `std::istringstream` - fallback if neither of the above are available