### PR TITLE
Fix relative URI resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ if(valijson_BUILD_TESTS)
         tests/test_date_time_format.cpp
         tests/test_double_parser.cpp
         tests/test_fetch_absolute_uri_document_callback.cpp
+        tests/test_fetch_relative_uri_document_callback.cpp
         tests/test_fetch_urn_document_callback.cpp
         tests/test_json_pointer.cpp
         tests/test_json11_adapter.cpp

--- a/examples/valijson_nlohmann_bundled.hpp
+++ b/examples/valijson_nlohmann_bundled.hpp
@@ -2023,23 +2023,27 @@ inline std::string resolveRelativeUri(
         return relativeUri;
     }
 
-    // Trivial case: The resolution scope is _not_ absolute
     const auto schemeEnd = parseScheme(resolutionScope);
-    if (!schemeEnd.has_value()) {
-        return resolutionScope + relativeUri;
+    std::string schemeAndAuthority;
+    std::string basePath;
+    if (schemeEnd.has_value()) {
+        // Extract scheme+authority, e.g. http://userinfo@example.com:8080
+        const auto authorityEnd = resolutionScope.find('/', *schemeEnd);
+        schemeAndAuthority = resolutionScope.substr(0, authorityEnd);
+
+        // Assume path starts immediately after scheme+authority
+        const std::string::size_type pathStart = schemeAndAuthority.size();
+
+        // Extract base path from resolution scope, or use '/' as default
+        basePath = pathStart < resolutionScope.size()
+                ? resolutionScope.substr(pathStart)
+                : "/";
+    } else {
+        // A relative resolution scope still represents a URI path. Relative
+        // references replace its final path segment rather than being appended
+        // directly to the complete filename.
+        basePath = resolutionScope;
     }
-
-    // Extract scheme+authority, e.g. http://userinfo@example.com:8080
-    const auto authorityEnd = resolutionScope.find('/', *schemeEnd);
-    const auto schemeAndAuthority = resolutionScope.substr(0, authorityEnd);
-
-    // Assume path starts immediately after scheme+authority
-    const std::string::size_type pathStart = schemeAndAuthority.size();
-
-    // Extract base path from resolution scope, or use '/' as default
-    std::string basePath = pathStart < resolutionScope.size()
-            ? resolutionScope.substr(pathStart)
-            : "/";
 
     // Strip everything after fragment marker if present
     const std::string::size_type baseFragmentPos = basePath.find('#');
@@ -2086,18 +2090,21 @@ inline std::string resolveRelativeUri(
         // stripping the base path of any segment after its last slash
         const std::string::size_type lastSlashPos = basePath.find_last_of('/');
         mergedPath = lastSlashPos == std::string::npos
-                ? "/" + relativePath
+                ? relativePath
                 : basePath.substr(0, lastSlashPos + 1) + relativePath;
     }
 
     // Resolve relative path segments
+    const bool absolutePath = !mergedPath.empty() && mergedPath[0] == '/';
     std::vector<std::string> segments;
     std::string segment;
     for (const char c : mergedPath) {
         if (c == '/') {
             if (segment == "..") {
-                if (!segments.empty()) {
+                if (!segments.empty() && segments.back() != "..") {
                     segments.pop_back();
+                } else if (!absolutePath) {
+                    segments.push_back(segment);
                 }
             } else if (!segment.empty() && segment != ".") {
                 segments.push_back(segment);
@@ -2108,15 +2115,17 @@ inline std::string resolveRelativeUri(
         }
     }
     if (segment == "..") {
-        if (!segments.empty()) {
+        if (!segments.empty() && segments.back() != "..") {
             segments.pop_back();
+        } else if (!absolutePath) {
+            segments.push_back(segment);
         }
     } else if (!segment.empty() && segment != ".") {
         segments.push_back(segment);
     }
 
     // Generate final normalised path
-    std::string normalisedPath = "/";
+    std::string normalisedPath = absolutePath ? "/" : "";
     for (auto itr = segments.begin(); itr != segments.end(); ++itr) {
         if (itr != segments.begin()) {
             normalisedPath += "/";

--- a/include/valijson/internal/uri.hpp
+++ b/include/valijson/internal/uri.hpp
@@ -64,23 +64,27 @@ inline std::string resolveRelativeUri(
         return relativeUri;
     }
 
-    // Trivial case: The resolution scope is _not_ absolute
     const auto schemeEnd = parseScheme(resolutionScope);
-    if (!schemeEnd.has_value()) {
-        return resolutionScope + relativeUri;
+    std::string schemeAndAuthority;
+    std::string basePath;
+    if (schemeEnd.has_value()) {
+        // Extract scheme+authority, e.g. http://userinfo@example.com:8080
+        const auto authorityEnd = resolutionScope.find('/', *schemeEnd);
+        schemeAndAuthority = resolutionScope.substr(0, authorityEnd);
+
+        // Assume path starts immediately after scheme+authority
+        const std::string::size_type pathStart = schemeAndAuthority.size();
+
+        // Extract base path from resolution scope, or use '/' as default
+        basePath = pathStart < resolutionScope.size()
+                ? resolutionScope.substr(pathStart)
+                : "/";
+    } else {
+        // A relative resolution scope still represents a URI path. Relative
+        // references replace its final path segment rather than being appended
+        // directly to the complete filename.
+        basePath = resolutionScope;
     }
-
-    // Extract scheme+authority, e.g. http://userinfo@example.com:8080
-    const auto authorityEnd = resolutionScope.find('/', *schemeEnd);
-    const auto schemeAndAuthority = resolutionScope.substr(0, authorityEnd);
-
-    // Assume path starts immediately after scheme+authority
-    const std::string::size_type pathStart = schemeAndAuthority.size();
-
-    // Extract base path from resolution scope, or use '/' as default
-    std::string basePath = pathStart < resolutionScope.size()
-            ? resolutionScope.substr(pathStart)
-            : "/";
 
     // Strip everything after fragment marker if present
     const std::string::size_type baseFragmentPos = basePath.find('#');
@@ -127,18 +131,21 @@ inline std::string resolveRelativeUri(
         // stripping the base path of any segment after its last slash
         const std::string::size_type lastSlashPos = basePath.find_last_of('/');
         mergedPath = lastSlashPos == std::string::npos
-                ? "/" + relativePath
+                ? relativePath
                 : basePath.substr(0, lastSlashPos + 1) + relativePath;
     }
 
     // Resolve relative path segments
+    const bool absolutePath = !mergedPath.empty() && mergedPath[0] == '/';
     std::vector<std::string> segments;
     std::string segment;
     for (const char c : mergedPath) {
         if (c == '/') {
             if (segment == "..") {
-                if (!segments.empty()) {
+                if (!segments.empty() && segments.back() != "..") {
                     segments.pop_back();
+                } else if (!absolutePath) {
+                    segments.push_back(segment);
                 }
             } else if (!segment.empty() && segment != ".") {
                 segments.push_back(segment);
@@ -149,15 +156,17 @@ inline std::string resolveRelativeUri(
         }
     }
     if (segment == "..") {
-        if (!segments.empty()) {
+        if (!segments.empty() && segments.back() != "..") {
             segments.pop_back();
+        } else if (!absolutePath) {
+            segments.push_back(segment);
         }
     } else if (!segment.empty() && segment != ".") {
         segments.push_back(segment);
     }
 
     // Generate final normalised path
-    std::string normalisedPath = "/";
+    std::string normalisedPath = absolutePath ? "/" : "";
     for (auto itr = segments.begin(); itr != segments.end(); ++itr) {
         if (itr != segments.begin()) {
             normalisedPath += "/";

--- a/tests/test_fetch_relative_uri_document_callback.cpp
+++ b/tests/test_fetch_relative_uri_document_callback.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include <valijson/adapters/rapidjson_adapter.hpp>
+#include <valijson/schema.hpp>
+#include <valijson/schema_parser.hpp>
+#include <valijson/validator.hpp>
+
+namespace {
+
+const rapidjson::Document * fetchRelativeUriDocument(const std::string &uri)
+{
+    rapidjson::Document *document = new rapidjson::Document();
+    document->SetObject();
+
+    if (uri == "json-schemas/schema-B.json") {
+        document->AddMember("$ref", "schema-C.json", document->GetAllocator());
+    } else if (uri == "json-schemas/schema-C.json") {
+        document->AddMember("type", "string", document->GetAllocator());
+    } else {
+        ADD_FAILURE() << "Unexpected schema URI: " << uri;
+        delete document;
+        return nullptr;
+    }
+
+    return document;
+}
+
+void freeRelativeUriDocument(const rapidjson::Document *document)
+{
+    delete document;
+}
+
+} // namespace
+
+TEST(FetchRelativeUriDocumentCallback, ResolvesNestedSiblingReferences)
+{
+    rapidjson::Document schemaDocument;
+    schemaDocument.SetObject();
+    schemaDocument.AddMember("$ref", "json-schemas/schema-B.json",
+            schemaDocument.GetAllocator());
+
+    valijson::Schema schema;
+    valijson::SchemaParser parser;
+    parser.populateSchema(valijson::adapters::RapidJsonAdapter(schemaDocument),
+            schema, fetchRelativeUriDocument, freeRelativeUriDocument);
+
+    rapidjson::Document validDocument;
+    validDocument.SetString("valid");
+    rapidjson::Document invalidDocument;
+    invalidDocument.SetInt(123);
+
+    valijson::Validator validator;
+    EXPECT_TRUE(validator.validate(schema,
+            valijson::adapters::RapidJsonAdapter(validDocument), nullptr));
+    EXPECT_FALSE(validator.validate(schema,
+            valijson::adapters::RapidJsonAdapter(invalidDocument), nullptr));
+}

--- a/tests/test_fetch_relative_uri_document_callback.cpp
+++ b/tests/test_fetch_relative_uri_document_callback.cpp
@@ -10,12 +10,16 @@ namespace {
 const rapidjson::Document * fetchRelativeUriDocument(const std::string &uri)
 {
     rapidjson::Document *document = new rapidjson::Document();
-    document->SetObject();
 
-    if (uri == "json-schemas/schema-B.json") {
-        document->AddMember("$ref", "schema-C.json", document->GetAllocator());
-    } else if (uri == "json-schemas/schema-C.json") {
-        document->AddMember("type", "string", document->GetAllocator());
+    if (uri == "schema-B.json") {
+        document->Parse(R"({
+            "type": "object",
+            "properties": {
+                "testC": { "$ref": "schema-C.json" }
+            }
+        })");
+    } else if (uri == "schema-C.json") {
+        document->Parse(R"({ "type": "object" })");
     } else {
         ADD_FAILURE() << "Unexpected schema URI: " << uri;
         delete document;
@@ -35,9 +39,12 @@ void freeRelativeUriDocument(const rapidjson::Document *document)
 TEST(FetchRelativeUriDocumentCallback, ResolvesNestedSiblingReferences)
 {
     rapidjson::Document schemaDocument;
-    schemaDocument.SetObject();
-    schemaDocument.AddMember("$ref", "json-schemas/schema-B.json",
-            schemaDocument.GetAllocator());
+    schemaDocument.Parse(R"({
+        "type": "object",
+        "properties": {
+            "testB": { "$ref": "schema-B.json" }
+        }
+    })");
 
     valijson::Schema schema;
     valijson::SchemaParser parser;
@@ -45,9 +52,9 @@ TEST(FetchRelativeUriDocumentCallback, ResolvesNestedSiblingReferences)
             schema, fetchRelativeUriDocument, freeRelativeUriDocument);
 
     rapidjson::Document validDocument;
-    validDocument.SetString("valid");
+    validDocument.Parse(R"({ "testB": { "testC": {} } })");
     rapidjson::Document invalidDocument;
-    invalidDocument.SetInt(123);
+    invalidDocument.Parse(R"({ "testB": { "testC": "invalid" } })");
 
     valijson::Validator validator;
     EXPECT_TRUE(validator.validate(schema,

--- a/tests/test_uri.cpp
+++ b/tests/test_uri.cpp
@@ -146,4 +146,12 @@ INSTANTIATE_TEST_SUITE_P(
                 UriResolutionTestCase{
                         "schemas/",
                         "child.json",
-                        "schemas/child.json"}));
+                        "schemas/child.json"},
+                UriResolutionTestCase{
+                        "json-schemas/schema-B.json",
+                        "schema-C.json",
+                        "json-schemas/schema-C.json"},
+                UriResolutionTestCase{
+                        "schema-B.json",
+                        "schema-C.json",
+                        "schema-C.json"}));

--- a/uri.md
+++ b/uri.md
@@ -1,0 +1,80 @@
+# URI resolution edge cases
+
+`valijson::internal::uri::resolveRelativeUri` resolves URI references against a base resolution scope. The existing tests in `tests/test_uri.cpp` cover 45 cases, including many of the normal and abnormal examples from RFC 3986, plus several Valijson-specific cases. All of those tests currently pass.
+
+The RFC test suites are deliberately named `Rfc3986ImplementedNormalExamples` and `Rfc3986ImplementedAbnormalExamples`: they contain only a subset of the RFC examples. Several omitted examples expose behavior that is inconsistent with RFC 3986.
+
+## Confirmed edge cases
+
+| Base URI                             | Reference                     | RFC 3986 result                    | Current result                                     |
+| ------------------------------------ | ----------------------------- | ---------------------------------- | -------------------------------------------------- |
+| `http://a/b/c/d;p?q`                 | `g:h`                         | `g:h`                              | `http://a/b/c/g:h`                                 |
+| `http://a/b/c/d;p?q`                 | `//g`                         | `http://g`                         | `http://a/g`                                       |
+| `http://a/b/c/d;p?q`                 | `#s`                          | `http://a/b/c/d;p?q#s`             | `http://a/b/c/d;p#s`                               |
+| `http://a/b/c/d;p?q`                 | `.`                           | `http://a/b/c/`                    | `http://a/b/c`                                     |
+| `http://a/b/c/d;p?q`                 | `..`                          | `http://a/b/`                      | `http://a/b`                                       |
+| `http://a/b/c/d;p?q`                 | `./g/.`                       | `http://a/b/c/g/`                  | `http://a/b/c/g`                                   |
+| `http://a/b/c/d;p?q`                 | `g//h`                        | `http://a/b/c/g//h`                | `http://a/b/c/g/h`                                 |
+| `http://a/b/c/d;p?q#old`             | empty                         | `http://a/b/c/d;p?q`               | `http://a/b/c/d;p?q#old`                           |
+| `http://example.com?version=1`       | `schema.json`                 | `http://example.com/schema.json`   | `http://example.com?version=1/schema.json`         |
+| `http://a/b/c/d;p?q`                 | `mailto:user@example.com`     | `mailto:user@example.com`          | `http://a/b/c/mailto:user@example.com`             |
+| `urn:example:a`                      | `b`                           | `urn:b`                            | `b`                                                |
+
+## Causes
+
+### Scheme detection
+
+`parseScheme` recognizes a scheme only when it is followed by `://`. RFC 3986 defines a scheme using the form `scheme:`, so absolute references such as `g:h`, `mailto:user@example.com`, `data:...`, and `file:/...` are not recognized as absolute. The special handling for URNs covers only one subset of valid non-`://` schemes.
+
+The same limitation affects base URIs without an authority component. For example, resolving `b` against `urn:example:a` loses the `urn:` scheme.
+
+### Network-path references
+
+A reference beginning with `//` supplies a new authority while inheriting the base scheme. The implementation treats it as an absolute path and retains the old authority. It then collapses the two leading slashes during path normalization.
+
+### Query and fragment handling
+
+The base query is removed before fragment-only references are handled. Consequently, resolving `#s` against a base containing `?q` loses that query.
+
+An empty reference returns the resolution scope immediately. Under RFC 3986, it inherits the base path and query but does not inherit the base fragment.
+
+### Dot segments and empty path segments
+
+Terminal `.` and `..` segments imply a trailing slash in the normalized path. The current segment-based normalization removes the segment but does not preserve that slash.
+
+The normalization also discards empty path segments, changing paths such as `g//h` to `g/h`. Empty non-dot segments are significant and should be preserved.
+
+There is also a boundary-safety issue when normalization produces an empty string from a path ending in `/`: the trailing-slash check indexes `normalisedPath[normalisedPath.size() - 1]` without first checking whether `normalisedPath` is empty.
+
+### Authority extraction
+
+When extracting an authority from a base URI, the implementation searches only for `/`. An authority can also be terminated by `?` or `#`. A base such as `http://example.com?version=1` therefore has its query incorrectly included in the authority.
+
+## Recommended test coverage
+
+The omitted RFC 3986 examples should be added first:
+
+- `g:h`
+- `//g`
+- `#s`
+- `.`
+- `..`
+- `./g/.`
+- `http:g`, using strict RFC behavior
+
+Additional regression coverage should include:
+
+- Absolute references using `https://`, `mailto:`, `data:`, and `file:/`.
+- Network-path references containing a path, query, and fragment.
+- Empty references and fragment-only references against bases with existing queries and fragments.
+- Empty query and fragment markers (`?` and `#`).
+- Terminal `.` and `..` segments at different path depths.
+- Repeated slashes in both base paths and references.
+- Authority-only bases followed by a query or fragment.
+- Authorities containing user information, ports, and IPv6 literals.
+- Relative resolution scopes and non-hierarchical base URIs.
+- Inputs that normalize to an empty path, exercised under sanitizers or a bounds-checked standard library.
+
+## Absolute-reference normalization policy
+
+RFC 3986 resolution removes dot segments from the path of an absolute reference. For example, resolving `http://x/a/../b` produces `http://x/b`. The helper currently returns recognized absolute references unchanged. Before adding this as a conformance test, decide whether the helper is intended to perform full RFC resolution or deliberately preserve absolute references verbatim.


### PR DESCRIPTION
This change addresses an issue where a resolution scope and relative URI would be incorrectly concatenated, and returned immediately

After digging deeper into RFC 3986, I can see that there are still some edge cases that are not yet covered. I will keep iterating on this in the lead up to v1.1.3