### PR TITLE
Catch std::out_of_range from stoul in resolveJsonPointer()

### DIFF
--- a/include/valijson/internal/json_pointer.hpp
+++ b/include/valijson/internal/json_pointer.hpp
@@ -225,6 +225,11 @@ inline AdapterType resolveJsonPointer(
             throwRuntimeError("Expected reference token to contain a "
                     "non-negative integer to identify an element in the "
                     "current array; actual token: " + referenceToken);
+        } catch (std::out_of_range &) {
+            throwRuntimeError("Expected reference token to contain a "
+                    "non-negative integer to identify an element in the "
+                    "current array, but the numeric token is too large; "
+                    "actual token: " + referenceToken);
         }
 #endif
     } else if (node.maybeObject()) {

--- a/tests/test_json_pointer.cpp
+++ b/tests/test_json_pointer.cpp
@@ -198,6 +198,24 @@ std::vector<std::shared_ptr<JsonPointerTestCase> >
         testCases.push_back(testCase);
     }
 
+    {
+        rapidjson::Value testArray;
+        testArray.SetArray();
+        testArray.PushBack("test0", allocator);
+        testArray.PushBack("test1", allocator);
+        testArray.PushBack("test2", allocator);
+
+        testCase = std::make_shared<JsonPointerTestCase>();
+        testCase->description = "Resolving '/test/99999999999999999999999999999999' in object containing "
+                "one member containing an array with 3 elements should throw an exception, since the "
+                "reference token is a syntactically valid but out-of-range non-negative integer";
+        testCase->value.SetObject();
+        testCase->value.AddMember("test", testArray, allocator);
+        testCase->jsonPointer = "/test/99999999999999999999999999999999";
+        testCase->expectedValue = nullptr;
+        testCases.push_back(testCase);
+    }
+
     //
     // Allow the "-" character is not useful within the context of this library,
     // there is an explicit check for it, so that a custom error message can


### PR DESCRIPTION
`resolveJsonPointer()` parses each array-index reference token with `std::stoul(referenceToken)` inside a try block, but the only catch clause handles `std::invalid_argument` (thrown when the token isn't a number at all, like `/abc`). It doesn't catch `std::out_of_range`, which `stoul` also throws when the token is a syntactically valid number that's just too big to fit in an `unsigned long` — something like `/test/99999999999999999999999999999999`. In that case the exception isn't converted into the library's usual `std::runtime_error` and instead escapes the function as-is.

That's inconsistent with how every other error in this function behaves, and with the test suite itself, which expects `resolveJsonPointer` to only ever throw `std::runtime_error` (see the `EXPECT_THROW(..., std::runtime_error)` loop in `test_json_pointer.cpp`). A caller who only catches `std::runtime_error`, as the docs and tests imply is safe, would have an unhandled `std::out_of_range` propagate instead.

I confirmed this with a small standalone harness (a minimal mock adapter satisfying just the template interface `resolveJsonPointer` needs, so no dependency on any real JSON backend) compiled directly against the unmodified header with `-DVALIJSON_USE_EXCEPTIONS=1`: a normal out-of-bounds index like `/test/3` on a 3-element array correctly threw `std::runtime_error`, but the oversized-token case threw `std::out_of_range` instead, reproducing the bug. After adding the extra `catch (std::out_of_range &)` clause (which reports the same kind of `throwRuntimeError` as the existing one), recompiling against the patched header fixed the oversized-token case while leaving the normal cases unchanged.

The fix is a one-clause addition next to the existing catch. I also added a test case to `test_json_pointer.cpp` alongside the existing out-of-bounds-index case, using an oversized numeric token, so this doesn't regress.
